### PR TITLE
39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,37 @@ jobs:
            COVERAGE=$(cargo llvm-cov report 2>/dev/null | grep TOTAL | awk '{print $NF}' || echo "N/A")
            echo "## Coverage: $COVERAGE" >> "$GITHUB_STEP_SUMMARY"
 
+  wasm-build:
+    name: Example WASM build
+    needs: msrv
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Load cached target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: example
+          key: wasm-example
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install trunk
+        uses: jetli/trunk-action@v0.5.0
+        with:
+          version: latest
+
+      - name: Build example with trunk
+        run: trunk build --release
+        working-directory: example
+
   benchmarks:
     name: Benchmarks
     needs: test
@@ -408,7 +439,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [msrv, check, fmt, docs, no_std, security, reuse, test, coverage, benchmarks, changelog, actionlint, release]
+    needs: [msrv, check, fmt, docs, no_std, security, reuse, test, coverage, benchmarks, wasm-build, changelog, actionlint, release]
     if: always()
     steps:
       - name: Check job status
@@ -425,11 +456,12 @@ jobs:
           echo "  Test: ${{ needs.test.result }}"
           echo "  Coverage: ${{ needs.coverage.result }}"
           echo "  Benchmarks: ${{ needs.benchmarks.result }}"
+          echo "  WASM build: ${{ needs.wasm-build.result }}"
           echo "  Changelog: ${{ needs.changelog.result }}"
           echo "  Actionlint: ${{ needs.actionlint.result }}"
           echo "  Release: ${{ needs.release.result }}"
-          
-          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || ("${{ needs.release.result }}" != "success" && "${{ needs.release.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
+
+          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || ("${{ needs.release.result }}" != "success" && "${{ needs.release.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
             echo "❌ CI failed"
             exit 1
           fi


### PR DESCRIPTION
Closes #39

## Summary

Add a `wasm-build` job to `.github/workflows/ci.yml` that builds `example/` via trunk on every PR and push, so demo regressions block merges to `main`.

## What

- New job `wasm-build` (name `Example WASM build`):
  - `dtolnay/rust-toolchain@master` with `targets: wasm32-unknown-unknown`
  - `Swatinem/rust-cache@v2` scoped to `workspaces: example`, cache key `wasm-example`
  - `jetli/trunk-action@v0.5.0` (latest trunk)
  - `trunk build --release` with `working-directory: example`
- Added to `ci-success` aggregator as a strict (non-skippable) requirement
- Depends only on `msrv` so it runs in parallel with the rest of the check matrix

## Validation

- `actionlint` clean locally
- `cd example && trunk build --release` clean locally