### PR TITLE
41

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+  TRUNK_PUBLIC_URL: /yew-nav-link/
+
+jobs:
+  build:
+    name: Build demo
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Load cached target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: example
+          key: pages-example
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install trunk
+        uses: jetli/trunk-action@v0.5.0
+        with:
+          version: latest
+
+      - name: Build demo with trunk
+        run: trunk build --release --public-url "$TRUNK_PUBLIC_URL"
+        working-directory: example
+
+      - name: SPA fallback (copy index.html to 404.html)
+        run: cp example/dist/index.html example/dist/404.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: example/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Closes #41

## Summary

Add a Pages workflow that builds the demo with trunk and deploys to <https://raprogramm.github.io/yew-nav-link/> on every push to `main`.

## What

- New `.github/workflows/pages.yml`:
  - Triggers on push to `main` and manual `workflow_dispatch`
  - Permissions: `contents: read`, `pages: write`, `id-token: write`
  - Concurrency `pages`, `cancel-in-progress: false` so we never kill an in-flight deploy
  - Build job installs the `wasm32-unknown-unknown` target, drops in trunk via `jetli/trunk-action`, and runs `trunk build --release --public-url /yew-nav-link/`
  - SPA fallback step copies `index.html` to `404.html` so client-side routes like `/yew-nav-link/blog` survive GitHub Pages 404s
  - Upload via `actions/upload-pages-artifact@v3`
  - Deploy job uses `actions/deploy-pages@v4` and exposes the URL as a job output

## Validation

- Built locally with `trunk build --release --public-url /yew-nav-link/` — generated paths verified to use `/yew-nav-link/…` correctly
- `actionlint .github/workflows/pages.yml` clean
- GitHub Pages already configured in repo settings (`build_type: workflow`, `https_enforced: true`)

## Notes

This PR does not change `Cargo.toml` so the existing release job will not republish on merge.