### PR TITLE
43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-10
+
+### Added
+
+- Re-export `BreadcrumbLabelProvider` at the crate root so consumers can write `use yew_nav_link::BreadcrumbLabelProvider;` instead of reaching into the `hooks::` submodule. Purely additive; no behaviour change.
+
 ## [0.9.1] - 2026-05-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "criterion",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-nav-link"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 edition = "2024"
 rust-version = "1.95"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,8 @@ pub use components::{
 };
 pub use errors::{NavError, NavResult};
 pub use hooks::{
-    BreadcrumbItem, Navigation, use_breadcrumbs, use_is_active, use_is_exact_active,
-    use_is_partial_active, use_navigation, use_query_params, use_route_info
+    BreadcrumbItem, BreadcrumbLabelProvider, Navigation, use_breadcrumbs, use_is_active,
+    use_is_exact_active, use_is_partial_active, use_navigation, use_query_params, use_route_info
 };
 pub use nav::{NavDivider, NavDividerProps, NavItem, NavItemProps, NavList, NavListProps};
 pub use utils::{is_absolute, join_paths, normalize_path};


### PR DESCRIPTION
Closes #43

## Summary

Re-export `BreadcrumbLabelProvider` at the crate root so users can write `use yew_nav_link::BreadcrumbLabelProvider;`. Purely additive — bumps `0.9.1 → 0.9.2`.

## Changes

- `src/lib.rs` — add `BreadcrumbLabelProvider` to the `pub use hooks::{…}` line
- `Cargo.toml` — version bump
- `CHANGELOG.md` — `[0.9.2]` section

## Validation

- `cargo check --all-features` — clean
- pre-commit (fmt + clippy + deny + audit + actionlint) — clean

## Notes

This will trigger the auto-publish path (`Cargo.toml.version != latest tag`) on merge: `0.9.2` ships to crates.io and a `v0.9.2` GitHub release is created.