### PR TITLE
47

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "yew",
  "yew-router",

--- a/example/index.html
+++ b/example/index.html
@@ -11,6 +11,7 @@ SPDX-License-Identifier: MIT
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link data-trunk rel="scss" href="styles/main.scss">
 </head>
 <body>
     <div id="app"></div>

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -40,234 +40,6 @@ enum Route {
     QueryDemo
 }
 
-// ============ GLOBAL STYLES ============
-
-fn global_styles() -> Html {
-    html! {
-        <style>{r#"
-            :root {
-                --primary: #3b82f6;
-                --primary-dark: #2563eb;
-                --primary-light: #dbeafe;
-                --success: #10b981;
-                --warning: #f59e0b;
-                --danger: #ef4444;
-                --text: #1e293b;
-                --text-muted: #64748b;
-                --text-light: #94a3b8;
-                --bg: #f8fafc;
-                --bg-card: #ffffff;
-                --border: #e2e8f0;
-                --shadow: 0 1px 3px rgba(0,0,0,0.1);
-                --shadow-lg: 0 10px 15px -3px rgba(0,0,0,0.1);
-                --radius: 0.5rem;
-                --radius-sm: 0.375rem;
-            }
-
-            * { box-sizing: border-box; margin: 0; padding: 0; }
-
-            body {
-                font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-                color: var(--text);
-                background: var(--bg);
-                line-height: 1.6;
-            }
-
-            .app-container { min-height: 100vh; display: flex; flex-direction: column; }
-
-            .main-nav {
-                background: var(--bg-card);
-                border-bottom: 1px solid var(--border);
-                padding: 0 2rem;
-                position: sticky;
-                top: 0;
-                z-index: 100;
-                box-shadow: var(--shadow);
-            }
-
-            .main-nav .nav-content {
-                max-width: 1200px;
-                margin: 0 auto;
-                display: flex;
-                align-items: center;
-                gap: 0.5rem;
-                padding: 0.75rem 0;
-            }
-
-            .main-nav .logo {
-                font-weight: 700;
-                font-size: 1.25rem;
-                color: var(--primary);
-                text-decoration: none;
-                margin-right: 2rem;
-                display: flex;
-                align-items: center;
-                gap: 0.5rem;
-            }
-
-            .main-nav .nav-links {
-                display: flex;
-                gap: 0.25rem;
-                flex-wrap: wrap;
-            }
-
-            .container {
-                max-width: 1200px;
-                margin: 0 auto;
-                padding: 2rem;
-                width: 100%;
-            }
-
-            .page-header {
-                margin-bottom: 2rem;
-                padding-bottom: 1rem;
-                border-bottom: 1px solid var(--border);
-            }
-
-            .page-header h1 {
-                font-size: 2rem;
-                font-weight: 700;
-                color: var(--text);
-                margin-bottom: 0.5rem;
-            }
-
-            .page-header p {
-                color: var(--text-muted);
-                font-size: 1.1rem;
-            }
-
-            .section {
-                background: var(--bg-card);
-                border: 1px solid var(--border);
-                border-radius: var(--radius);
-                padding: 1.5rem;
-                margin-bottom: 1.5rem;
-                box-shadow: var(--shadow);
-            }
-
-            .section-title {
-                font-size: 1.25rem;
-                font-weight: 600;
-                margin-bottom: 1rem;
-                color: var(--text);
-            }
-
-            .section-desc {
-                color: var(--text-muted);
-                margin-bottom: 1rem;
-                font-size: 0.95rem;
-            }
-
-            .code-block {
-                background: #1e293b;
-                color: #e2e8f0;
-                padding: 1rem;
-                border-radius: var(--radius-sm);
-                font-family: 'Monaco', 'Consolas', monospace;
-                font-size: 0.85rem;
-                overflow-x: auto;
-                margin: 1rem 0;
-                line-height: 1.5;
-            }
-
-            .demo-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-                gap: 1rem;
-                margin-top: 1rem;
-            }
-
-            .card {
-                background: var(--bg);
-                border: 1px solid var(--border);
-                border-radius: var(--radius-sm);
-                padding: 1rem;
-            }
-
-            .card-title {
-                font-weight: 600;
-                margin-bottom: 0.5rem;
-                color: var(--text);
-            }
-
-            .badge {
-                display: inline-block;
-                padding: 0.25rem 0.75rem;
-                border-radius: 9999px;
-                font-size: 0.75rem;
-                font-weight: 600;
-            }
-
-            .badge-blue { background: var(--primary-light); color: var(--primary); }
-            .badge-green { background: #d1fae5; color: var(--success); }
-            .badge-yellow { background: #fef3c7; color: var(--warning); }
-            .badge-red { background: #fee2e2; color: var(--danger); }
-
-            .info-box {
-                background: var(--primary-light);
-                border-left: 4px solid var(--primary);
-                padding: 1rem;
-                border-radius: var(--radius-sm);
-                margin: 1rem 0;
-            }
-
-            .info-box p { color: var(--primary-dark); font-size: 0.9rem; }
-
-            .status-active { color: var(--success); font-weight: 600; }
-            .status-inactive { color: var(--text-muted); }
-
-            pre {
-                background: #1e293b;
-                color: #e2e8f0;
-                padding: 1rem;
-                border-radius: var(--radius-sm);
-                overflow-x: auto;
-                font-size: 0.85rem;
-                line-height: 1.5;
-            }
-
-            .flex-row { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; }
-            .flex-col { display: flex; flex-direction: column; gap: 0.5rem; }
-            .gap-1 { gap: 1rem; }
-            .mt-1 { margin-top: 1rem; }
-            .mb-1 { margin-bottom: 1rem; }
-
-            table {
-                width: 100%;
-                border-collapse: collapse;
-                margin: 1rem 0;
-            }
-
-            th, td {
-                padding: 0.75rem;
-                text-align: left;
-                border-bottom: 1px solid var(--border);
-            }
-
-            th {
-                background: var(--bg);
-                font-weight: 600;
-                font-size: 0.875rem;
-                color: var(--text-muted);
-            }
-
-            .breadcrumb-demo {
-                display: flex;
-                gap: 0.5rem;
-                align-items: center;
-                padding: 1rem;
-                background: var(--bg);
-                border-radius: var(--radius-sm);
-                margin: 1rem 0;
-            }
-
-            .breadcrumb-separator {
-                color: var(--text-light);
-            }
-        "#}</style>
-    }
-}
-
 // ============ DEMO PAGES ============
 
 #[component]
@@ -1525,29 +1297,26 @@ let query_params: HashMap<String, String> = use_query_params();
 #[component]
 fn App() -> Html {
     html! {
-        <>
-            { global_styles() }
-            <BrowserRouter>
-                <div class="app-container">
-                    <Navigation />
-                    <Switch<Route> render={|route: Route| {
-                        match route {
-                            Route::Home => html! { <HomePage/> },
-                            Route::BasicLinks => html! { <BasicLinksPage/> },
-                            Route::Components => html! { <ComponentsPage/> },
-                            Route::TabsDemo => html! { <TabsDemoPage/> },
-                            Route::PaginationDemo => html! { <PaginationDemoPage/> },
-                            Route::DropdownDemo => html! { <DropdownDemoPage/> },
-                            Route::HooksDemo => html! { <HooksDemoPage/> },
-                            Route::UtilsDemo => html! { <UtilsDemoPage/> },
-                            Route::Blog | Route::BlogPost { .. } => html! { <BlogPage/> },
-                            Route::Nested | Route::NestedFirst | Route::NestedSecond => html! { <NestedPage/> },
-                            Route::QueryDemo => html! { <QueryDemoPage/> },
-                        }
-                    }} />
-                </div>
-            </BrowserRouter>
-        </>
+        <BrowserRouter>
+            <div class="app-container">
+                <Navigation />
+                <Switch<Route> render={|route: Route| {
+                    match route {
+                        Route::Home => html! { <HomePage/> },
+                        Route::BasicLinks => html! { <BasicLinksPage/> },
+                        Route::Components => html! { <ComponentsPage/> },
+                        Route::TabsDemo => html! { <TabsDemoPage/> },
+                        Route::PaginationDemo => html! { <PaginationDemoPage/> },
+                        Route::DropdownDemo => html! { <DropdownDemoPage/> },
+                        Route::HooksDemo => html! { <HooksDemoPage/> },
+                        Route::UtilsDemo => html! { <UtilsDemoPage/> },
+                        Route::Blog | Route::BlogPost { .. } => html! { <BlogPage/> },
+                        Route::Nested | Route::NestedFirst | Route::NestedSecond => html! { <NestedPage/> },
+                        Route::QueryDemo => html! { <QueryDemoPage/> },
+                    }
+                }} />
+            </div>
+        </BrowserRouter>
     }
 }
 

--- a/example/styles/_components.scss
+++ b/example/styles/_components.scss
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+.section {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    box-shadow: var(--shadow);
+}
+
+.section-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: var(--text);
+}
+
+.section-desc {
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
+}
+
+.code-block,
+pre {
+    background: var(--code-bg);
+    color: var(--code-fg);
+    padding: 1rem;
+    border-radius: var(--radius-sm);
+    font-family: 'Monaco', 'Consolas', monospace;
+    font-size: 0.85rem;
+    overflow-x: auto;
+    margin: 1rem 0;
+    line-height: 1.5;
+}
+
+.demo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 1rem;
+}
+
+.card-title {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: var(--text);
+}
+
+.badge {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.badge-blue { background: var(--primary-light); color: var(--primary); }
+.badge-green { background: #d1fae5; color: var(--success); }
+.badge-yellow { background: #fef3c7; color: var(--warning); }
+.badge-red { background: #fee2e2; color: var(--danger); }
+
+.info-box {
+    background: var(--primary-light);
+    border-left: 4px solid var(--primary);
+    padding: 1rem;
+    border-radius: var(--radius-sm);
+    margin: 1rem 0;
+
+    p {
+        color: var(--primary-dark);
+        font-size: 0.9rem;
+    }
+}
+
+.status-active {
+    color: var(--success);
+    font-weight: 600;
+}
+
+.status-inactive {
+    color: var(--text-muted);
+}
+
+.flex-row {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.flex-col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.gap-1 { gap: 1rem; }
+.mt-1 { margin-top: 1rem; }
+.mb-1 { margin-bottom: 1rem; }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0;
+
+    th,
+    td {
+        padding: 0.75rem;
+        text-align: left;
+        border-bottom: 1px solid var(--border);
+    }
+
+    th {
+        background: var(--bg);
+        font-weight: 600;
+        font-size: 0.875rem;
+        color: var(--text-muted);
+    }
+}
+
+.breadcrumb-demo {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 1rem;
+    background: var(--bg);
+    border-radius: var(--radius-sm);
+    margin: 1rem 0;
+}
+
+.breadcrumb-separator {
+    color: var(--text-light);
+}

--- a/example/styles/_dark.scss
+++ b/example/styles/_dark.scss
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Dark theme: kicks in when the visitor's OS is set to dark mode.
+// We override design tokens at :root so every component that uses them
+// (cards, navigation, breadcrumbs, badges, …) flips automatically.
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --primary: #60a5fa;
+        --primary-dark: #93c5fd;
+        --primary-light: rgba(96, 165, 250, 0.15);
+
+        --success: #34d399;
+        --warning: #fbbf24;
+        --danger: #f87171;
+
+        --text: #e2e8f0;
+        --text-muted: #94a3b8;
+        --text-light: #64748b;
+
+        --bg: #0f172a;
+        --bg-card: #1e293b;
+        --border: #334155;
+
+        // Code blocks invert: lighter slab, dark foreground.
+        --code-bg: #020617;
+        --code-fg: #cbd5e1;
+
+        --shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+        --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.6);
+    }
+
+    // Soft tints for the variant badges so they remain readable on dark cards.
+    .badge-green { background: rgba(52, 211, 153, 0.15); color: var(--success); }
+    .badge-yellow { background: rgba(251, 191, 36, 0.15); color: var(--warning); }
+    .badge-red { background: rgba(248, 113, 113, 0.15); color: var(--danger); }
+}

--- a/example/styles/_layout.scss
+++ b/example/styles/_layout.scss
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+.app-container {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.main-nav {
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border);
+    padding: 0 2rem;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    box-shadow: var(--shadow);
+
+    .nav-content {
+        max-width: 1200px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 0;
+    }
+
+    .logo {
+        font-weight: 700;
+        font-size: 1.25rem;
+        color: var(--primary);
+        text-decoration: none;
+        margin-right: 2rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .nav-links {
+        display: flex;
+        gap: 0.25rem;
+        flex-wrap: wrap;
+    }
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    width: 100%;
+}
+
+.page-header {
+    margin-bottom: 2rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border);
+
+    h1 {
+        font-size: 2rem;
+        font-weight: 700;
+        color: var(--text);
+        margin-bottom: 0.5rem;
+    }
+
+    p {
+        color: var(--text-muted);
+        font-size: 1.1rem;
+    }
+}

--- a/example/styles/_reset.scss
+++ b/example/styles/_reset.scss
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: var(--text);
+    background: var(--bg);
+    line-height: 1.6;
+}

--- a/example/styles/_tokens.scss
+++ b/example/styles/_tokens.scss
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Design tokens — single source of truth for the demo's visual language.
+// Light theme is the default; _dark.scss overrides via prefers-color-scheme.
+
+:root {
+    --primary: #3b82f6;
+    --primary-dark: #2563eb;
+    --primary-light: #dbeafe;
+
+    --success: #10b981;
+    --warning: #f59e0b;
+    --danger: #ef4444;
+
+    --text: #1e293b;
+    --text-muted: #64748b;
+    --text-light: #94a3b8;
+
+    --bg: #f8fafc;
+    --bg-card: #ffffff;
+    --border: #e2e8f0;
+
+    --code-bg: #1e293b;
+    --code-fg: #e2e8f0;
+
+    --shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+
+    --radius: 0.5rem;
+    --radius-sm: 0.375rem;
+}

--- a/example/styles/main.scss
+++ b/example/styles/main.scss
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Order matters: tokens first (define vars), reset (uses vars), then
+// layout/components, then dark-mode overrides as the final layer.
+
+@use "tokens";
+@use "reset";
+@use "layout";
+@use "components";
+@use "dark";


### PR DESCRIPTION
Closes #47

## Summary

Replace the ~220-line inline `<style>` block in `example/src/lib.rs` with a proper SCSS source tree compiled by trunk, and add a `prefers-color-scheme: dark` variant so the demo respects the visitor's OS preference.

## What

- `example/styles/_tokens.scss` — design tokens as CSS custom properties (colours, spacing, radii, shadows, code-block colours)
- `example/styles/_reset.scss` — minimal box-sizing / typography reset
- `example/styles/_layout.scss` — app shell, sticky nav with nested rules, page header
- `example/styles/_components.scss` — cards, badges, info boxes, code blocks, tables, breadcrumb scaffolding
- `example/styles/_dark.scss` — token overrides under `@media (prefers-color-scheme: dark)`, plus tinted variant badges so they stay legible on dark cards
- `example/styles/main.scss` — `@use` entry point ordered as the cascade requires
- `example/index.html` — picks up the bundle via `<link data-trunk rel="scss" href="styles/main.scss">`
- `example/src/lib.rs` — `global_styles()` function and its call site in `App` removed

## Validation

- `trunk build --release` succeeds locally; `dist/` ships `main-*.css` and `index.html` references it (no inline `<style>`)
- `cargo +nightly fmt --check` clean
- pre-commit (fmt + clippy + deny + audit + actionlint) clean

## Out of scope

Manual light/dark toggle button — that needs `web-sys` features (`Storage`, `DomTokenList`) and a `ThemeToggle` component. Will be a separate small PR.

## Notes

This PR does not touch `Cargo.toml`, so the release job will skip on merge.