### PR TITLE
50

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,12 +426,38 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        if: steps.version_check.outputs.version_changed == 'true'
+        env:
+          VERSION: ${{ steps.version_check.outputs.current_version }}
+        run: |
+          # Pull the section between "## [VERSION] - …" (exclusive) and the
+          # next "## [" header (exclusive). Falls back to a generic line if
+          # the entry is missing so the release is still populated.
+          notes_file="$(mktemp)"
+          awk -v v="$VERSION" '
+            BEGIN { in_section = 0 }
+            /^## \[/ {
+              if (in_section) { exit }
+              if ($0 ~ "^## \\[" v "\\]") { in_section = 1; next }
+            }
+            in_section { print }
+          ' CHANGELOG.md > "$notes_file"
+
+          if [ ! -s "$notes_file" ]; then
+            echo "Release v$VERSION." > "$notes_file"
+          fi
+
+          echo "path=$notes_file" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub release
         if: steps.version_check.outputs.version_changed == 'true'
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version_check.outputs.current_version }}
           name: v${{ steps.version_check.outputs.current_version }}
+          body_path: ${{ steps.notes.outputs.path }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #50

## Bug

The release job uses \`actions/create-release@v1\`, deprecated since 2020. It silently ignores any input it does not recognise. Our config passes \`name\` and \`generate_release_notes\` — both unsupported by that action — so every release published so far (\`v0.9.0\`, \`v0.9.1\`, \`v0.9.2\`) has the bare tag as title and **empty body**.

Runner annotations confirm:

\`\`\`
Unexpected input(s) 'name', 'generate_release_notes', valid inputs are
['tag_name', 'release_name', 'body', 'body_path', 'draft', 'prerelease',
 'commitish', 'owner', 'repo']
\`\`\`

## Fix

- Replace \`actions/create-release@v1\` with \`softprops/action-gh-release@v2\`
- Add an \`Extract release notes\` step that pulls the section between the matching \`## [VERSION] - …\` header and the next version header in \`CHANGELOG.md\` via \`awk\`, writes it to a temp file, and exposes the path
- Pass that file via \`body_path\` and keep \`generate_release_notes: true\` so GitHub appends an auto-generated PR list under the handwritten excerpt
- Fallback to a single-line \`Release v\$VERSION.\` if the section is empty

## Validation

- \`actionlint\` clean
- Local awk extraction tested against current CHANGELOG (\`v0.9.2\` section returns the expected three-line block)

## Follow-up

Backfilling \`v0.9.0\` … \`v0.9.2\` empty bodies via \`gh release edit\` happens once this PR lands.

## Notes

This PR doesn't change \`Cargo.toml\`, so the release job will skip on merge — first real exercise of the new step lands with the next version bump.