### PR TITLE
53

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -94,7 +94,7 @@ impl BreadcrumbLabelProvider for DemoBreadcrumbLabels {
 #[component]
 fn Navigation() -> Html {
     html! {
-        <nav class="main-nav">
+        <nav class="main-nav" aria-label="Main navigation">
             <div class="nav-content">
                 <NavLink<Route>
                     to={Route::Home}
@@ -1688,29 +1688,34 @@ fn App() -> Html {
         <ContextProvider<BreadcrumbLabelProviderContext> context={(*label_ctx).clone()}>
             <BrowserRouter>
                 <div class="app-container">
+                    <a class="skip-link" href="#main-content">{ "Skip to content" }</a>
                     <Navigation />
-                    <Switch<Route> render={|route: Route| {
-                        match route {
-                            Route::Home => html! { <HomePage/> },
-                            Route::BasicLinks => html! { <BasicLinksPage/> },
-                            Route::Components => html! { <ComponentsPage/> },
-                            Route::TabsDemo => html! { <TabsDemoPage/> },
-                            Route::PaginationDemo => html! { <PaginationDemoPage/> },
-                            Route::DropdownDemo => html! { <DropdownDemoPage/> },
-                            Route::HooksDemo => html! { <HooksDemoPage/> },
-                            Route::UtilsDemo => html! { <UtilsDemoPage/> },
-                            Route::Blog | Route::BlogPost { .. } => html! { <BlogPage/> },
-                            Route::Nested | Route::NestedFirst | Route::NestedSecond => {
-                                html! { <NestedPage/> }
+                    <main id="main-content" tabindex="-1">
+                        <Switch<Route> render={|route: Route| {
+                            match route {
+                                Route::Home => html! { <HomePage/> },
+                                Route::BasicLinks => html! { <BasicLinksPage/> },
+                                Route::Components => html! { <ComponentsPage/> },
+                                Route::TabsDemo => html! { <TabsDemoPage/> },
+                                Route::PaginationDemo => html! { <PaginationDemoPage/> },
+                                Route::DropdownDemo => html! { <DropdownDemoPage/> },
+                                Route::HooksDemo => html! { <HooksDemoPage/> },
+                                Route::UtilsDemo => html! { <UtilsDemoPage/> },
+                                Route::Blog | Route::BlogPost { .. } => {
+                                    html! { <BlogPage/> }
+                                }
+                                Route::Nested
+                                | Route::NestedFirst
+                                | Route::NestedSecond => html! { <NestedPage/> },
+                                Route::QueryDemo => html! { <QueryDemoPage/> },
+                                Route::Breadcrumbs | Route::BreadcrumbsTeam { .. } => {
+                                    html! { <BreadcrumbsPage/> }
+                                }
+                                Route::Customization => html! { <CustomizationPage/> },
+                                Route::Errors => html! { <ErrorsPage/> }
                             }
-                            Route::QueryDemo => html! { <QueryDemoPage/> },
-                            Route::Breadcrumbs | Route::BreadcrumbsTeam { .. } => {
-                                html! { <BreadcrumbsPage/> }
-                            }
-                            Route::Customization => html! { <CustomizationPage/> },
-                            Route::Errors => html! { <ErrorsPage/> }
-                        }
-                    }} />
+                        }} />
+                    </main>
                 </div>
             </BrowserRouter>
         </ContextProvider<BreadcrumbLabelProviderContext>>

--- a/example/styles/_a11y.scss
+++ b/example/styles/_a11y.scss
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+// Accessibility scaffolding shared by every page:
+// * a "Skip to content" link that becomes visible on keyboard focus,
+// * a strong, theme-aware :focus-visible ring,
+// * honour the user's reduced-motion preference.
+
+.skip-link {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 200;
+    padding: 0.75rem 1rem;
+    background: var(--primary);
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    border-radius: 0 0 var(--radius-sm) 0;
+    transform: translateY(-100%);
+    transition: transform 0.15s ease-out;
+
+    &:focus,
+    &:focus-visible {
+        transform: translateY(0);
+        outline: 2px solid var(--primary-dark);
+        outline-offset: 2px;
+    }
+}
+
+// Suppress browser default outline only when we have a clear keyboard focus
+// indicator below; mouse focus stays unstyled per platform convention.
+:focus {
+    outline: none;
+}
+
+:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+}
+
+// `<main>` carries tabindex="-1" so the skip-link can move focus into it; we
+// don't want a permanent outline on a non-interactive container.
+main:focus,
+main:focus-visible {
+    outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
+    }
+}

--- a/example/styles/main.scss
+++ b/example/styles/main.scss
@@ -8,4 +8,5 @@
 @use "reset";
 @use "layout";
 @use "components";
+@use "a11y";
 @use "dark";


### PR DESCRIPTION
Closes #53

## Summary

Bring the demo's surrounding chrome up to WCAG 2.1 AA-friendly defaults: skip link, focus-visible ring, proper landmark roles, and `prefers-reduced-motion` honoured. The library's own ARIA on its components is unchanged.

## Changes

- **`<main id="main-content" tabindex="-1">`** wraps the routed `Switch` so screen readers and the skip link have a real landmark to jump to.
- **Skip-to-content link**: first focusable element, hidden until keyboard focus, slides into view, jumps focus directly into `<main>`.
- **`aria-label="Main navigation"`** on the top `<nav>` so screen readers can distinguish it from any future breadcrumb / sub-nav.
- **`example/styles/_a11y.scss`**:
  - Strong `:focus-visible` outline scoped so the non-interactive `<main>` container does not show a permanent ring.
  - Skip-link styling.
  - `@media (prefers-reduced-motion: reduce)` block that brings animation and transition durations to ~0.
- `main.scss` `@use`-s the new partial after components but before dark to keep theme overrides authoritative.

## Validation

- `cd example && trunk build --release` clean
- `actionlint` clean
- pre-commit (fmt + clippy + deny + audit + actionlint) clean

## Notes

This PR doesn't change `Cargo.toml`, so the release job will skip on merge. Pages will redeploy automatically.

Library-level addition of `aria-current="page"` to active `NavLink` is intentionally out of scope — that requires touching `<Link>` rendering and will land as a separate, possibly version-bumping issue.