### PR TITLE
59

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,18 @@ pub struct BreadcrumbItem {
 
 ---
 
+## Project documentation
+
+| File | Purpose |
+|------|---------|
+| [`docs/REQUIREMENTS.md`](docs/REQUIREMENTS.md) | Functional and non-functional requirements (what the crate does, the constraints under which it does it) |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Module layout, the active-state algorithm, hook contracts, breadcrumb context flow |
+| [`docs/ROADMAP.md`](docs/ROADMAP.md) | Trajectory toward 0.10 (breaking-change pass) and 1.0 (API freeze) |
+| [`SECURITY.md`](SECURITY.md) | Coordinated disclosure policy |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Workflow, commit format, code standards |
+
+---
+
 ## Migration Guides
 
 For a full release-by-release log, see [CHANGELOG.md](CHANGELOG.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,159 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Architecture
+
+This is a design rationale, not a tutorial. For the *what*, read the
+[crate docs](https://docs.rs/yew-nav-link). For the *why*, read on.
+
+## 1. Crate layout
+
+```text
+src/
+├── lib.rs            Public API and re-exports. The crate root re-exports
+│                     every type a typical consumer will reach for.
+├── active_link/      The NavLink<R> component, the Match enum, and the
+│   ├── mod.rs        per-render utility that decides the active state.
+│   ├── nav_link.rs
+│   ├── props.rs
+│   ├── mode.rs
+│   └── utils.rs
+├── nav/              Structural primitives that don't care about routing:
+│                     NavList, NavItem, NavDivider. These are render-only.
+├── components/       Higher-level UI components built on top of nav/:
+│                     badges, dropdowns, headers, icons, tabs, pagination,
+│                     etc.
+├── hooks/            Reactive hooks. Split into route_info/ (read-only
+│                     state) and navigation/ (effects + query params).
+├── utils/            Pure functions (paths, URL codec, keyboard helpers).
+│                     No yew dependency.
+├── attrs.rs          Type-safe attribute builders for consumers who roll
+│                     their own elements.
+└── errors.rs         NavError + NavResult<T>.
+```
+
+The split keeps three rules invariant:
+
+- **`utils/` is leaf** — no dependency on yew. It is unit-testable on its
+  own and could be carved into a sibling crate later without churn.
+- **`active_link/` is the only place that knows about active-state
+  matching.** Hooks delegate to the same primitive (`is_path_prefix`).
+- **Components never own routing state.** `NavTabs` and `Pagination` accept
+  the active index / page through props; the consumer holds the
+  `use_state`. The library is render-only above the routing layer.
+
+## 2. The active-state algorithm
+
+`NavLink<R>` and the active-state hooks all answer one question: given a
+target route `to: R` and the currently matched route, is `to` *active*?
+
+```rust
+fn is_active<R: Routable + PartialEq>(
+    current: Option<R>,
+    target: &R,
+    partial: bool,
+) -> bool {
+    let Some(current) = current else { return false };
+    if partial {
+        is_path_prefix(&target.to_path(), &current.to_path())
+    } else {
+        &current == target
+    }
+}
+```
+
+`is_path_prefix(prefix, full)` is **segment-wise**: `/docs` is a prefix of
+`/docs/api` but not of `/documentation`. We compute it by splitting both on
+`/`, dropping empty fragments, and checking that the prefix's segments
+match the head of `full`'s segments.
+
+Why segment-wise? Because string-prefix matching has a long history of
+false positives (e.g. `/admin` matching `/administrator`) and yew-router's
+`Routable` enum gives us proper `to_path()` strings to work with.
+
+## 3. The hook contract
+
+Every hook reads from yew-router's reactive state via `use_route::<R>()`
+and returns a *value*, not a callback registration. They re-render their
+caller when the URL changes; that is the entire integration point.
+
+```text
+URL changes ──► yew-router state updates ──► use_route()
+                                                │
+                                                ├── use_is_active(...)
+                                                ├── use_is_exact_active(...)
+                                                ├── use_is_partial_active(...)
+                                                ├── use_breadcrumbs()
+                                                └── use_route_info()
+```
+
+`use_navigation()` is the dual: pure outputs that *write* to the URL via
+yew-router's `Navigator`. It hands back ready-made `Callback<()>` so
+consumers don't have to repeat the `Callback::from(move |_| ...)` boiler
+plate.
+
+## 4. Custom breadcrumb labels
+
+`use_breadcrumbs` walks the current path and synthesises a list of
+`BreadcrumbItem<R>` entries — but the **label** for each entry is delegated
+to a `BreadcrumbLabelProvider` trait. The provider is injected through
+Yew's context system using a public newtype:
+
+```text
+                                ┌─────────────────────────────────┐
+                                │ BreadcrumbLabelProviderContext  │  newtype around
+                                │   ├── Rc<dyn ...Provider>       │  Rc<dyn Provider>
+                                └────────────┬────────────────────┘
+                                             │
+        <ContextProvider<BreadcrumbLabelProviderContext> context={…}>
+                          <App/>            │
+                            ...             │
+                            use_breadcrumbs() ──► reads ctx ──► label_for_path()
+```
+
+Why a newtype rather than putting `Rc<dyn Provider>` directly into context?
+Because yew-router's reactive context needs `PartialEq`, and we implement
+that as `Rc::ptr_eq` so re-renders only happen when the *concrete provider
+value* changes, not on every render where the provider is re-created via
+`Rc::clone`.
+
+This is the only stateful pattern in the crate; everything else is pure
+props.
+
+## 5. What we don't use, and why
+
+- **No `unsafe`.** There is no FFI surface and no performance hot-path that
+  would justify it.
+- **No `no_std`.** Yew requires `std` (allocations, `Rc`, threading
+  primitives behind WASM); the CI `no_std` job documents this and exits
+  successfully so a no-std intention is impossible to merge by accident.
+- **No async.** The hooks are synchronous; `use_navigation` returns
+  callbacks and yew-router does the rest.
+- **No internal `RefCell` / `Rc` mutability** beyond the breadcrumb
+  provider context, which is logically immutable per app lifecycle.
+
+## 6. Test layout
+
+```text
+tests/                                 # integration tests, Yew-aware
+benches/                               # criterion benchmarks (path utils)
+src/**/mod.rs (#[cfg(test)] modules)   # unit tests, focused per module
+```
+
+Integration tests live in `tests/` so they run against the public API
+exactly as a consumer would write code; this catches accidental breakage
+in re-exports that unit tests would miss.
+
+## 7. Demo crate (`example/`)
+
+The demo is a `cdylib` SPA served by trunk. It is intentionally **not** a
+workspace member of the library crate — its only purpose is to demonstrate
+the public API end-to-end and to be deployed to GitHub Pages.
+
+The demo is structured around a `DemoCard` component: every public
+component, hook, and utility appears in at least one card whose live
+preview is rendered side-by-side with the exact Rust snippet that
+produces it. The breadcrumb label provider is mounted at the top of the
+tree so `use_breadcrumbs` has a real provider to read.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,0 +1,203 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Requirements
+
+This document captures what `yew-nav-link` is contractually expected to do
+(functional requirements) and the constraints under which it does it
+(non-functional requirements). Anything claimed here is exercised by the
+test suite, the demo, or the CI pipeline.
+
+## 1. Functional requirements
+
+### 1.1 `NavLink<R>`
+
+**FR-NL-1.** Render a yew-router `Link<R>` with the same target and child
+content. The component is a wrapper, never a replacement.
+
+**FR-NL-2.** Compute an *active* state by comparing the current route to the
+target on every render:
+
+| `partial` | Match condition |
+|-----------|-----------------|
+| `false` (default) | exact equality between `current` and `to` |
+| `true` | `to.to_path()` is a path-segment prefix of `current.to_path()` |
+
+**FR-NL-3.** Apply two CSS classes to the rendered anchor:
+
+- The base class — defaults to `"nav-link"`, overridable via the `class`
+  prop (`&'static str`).
+- The active class — defaults to `"active"`, overridable via the
+  `active_class` prop (`&'static str`). Only emitted when *active* per
+  FR-NL-2.
+
+**FR-NL-4.** When the user clicks the link, the browser history is updated
+to `to` and the framework re-renders dependent hooks. Behaviour is delegated
+to `yew_router::Link`; the wrapper does not intercept clicks.
+
+### 1.2 `nav_link()` function
+
+**FR-FN-1.** Return an `Html` value that contains a `NavLink<R>` whose
+`partial` flag is derived from a `Match` argument:
+`Match::Exact` → `partial = false`, `Match::Partial` → `partial = true`.
+
+**FR-FN-2.** Accept the link text as `&str`; it is rendered as a single
+text child.
+
+### 1.3 Reactive hooks
+
+**FR-HK-1.** `use_route_info::<R>() -> Option<R>` returns the currently
+matched route, or `None` when no registered route matches.
+
+**FR-HK-2.** `use_is_active(route)` and the `use_is_exact_active(route)`
+alias return `true` iff the current route equals `route`.
+
+**FR-HK-3.** `use_is_partial_active(route)` returns `true` iff
+`route.to_path()` is a path-segment prefix of the current path.
+
+**FR-HK-4.** `use_navigation::<R>() -> Navigation<R>` returns a value-type
+struct exposing pre-built callbacks: `push_callback`, `replace_callback`,
+`go_callback`, `go_back`, `go_forward`. Each callback is `Callback<()>`
+(or `Callback<i32>` for `go_callback`) so consumers can adapt with
+`.reform(...)` for `onclick` handlers.
+
+**FR-HK-5.** `use_query_params() -> HashMap<String, String>` parses the
+current URL's query string into a flat map; reactive on every URL change.
+
+**FR-HK-6.** `use_breadcrumbs::<R>() -> Vec<BreadcrumbItem<R>>` builds a
+breadcrumb trail from the current path. The label of each item comes from a
+`BreadcrumbLabelProvider` injected into the tree via
+`BreadcrumbLabelProviderContext`. When no provider is present the path
+itself is used as the label. The last item has `is_active == true`.
+
+### 1.4 Components
+
+The crate ships UI components that are render-only — they hold no business
+logic and accept all required state through props.
+
+| Component | Role |
+|-----------|------|
+| `NavList` | `<ul>` with sensible ARIA defaults |
+| `NavItem` | `<li>` |
+| `NavDivider` | `<hr>` |
+| `NavHeader` | section heading inside a list |
+| `NavText` | inert text inside a list |
+| `NavBadge` | inline pill, variant + optional `pill=true` |
+| `NavIcon`, `NavLinkWithIcon` | icon container + paired layout helper |
+| `NavTabs`, `NavTab`, `NavTabPanel` | tab strip; consumer drives `active` |
+| `NavDropdown`, `NavDropdownItem`, `NavDropdownDivider` | self-managed open/close menu |
+| `Pagination`, `PageItem`, `PageLink` | full pagination renderer + lower-level building blocks |
+
+### 1.5 Errors
+
+**FR-ER-1.** `NavError` is a `pub enum` with three variants:
+`RouteNotFound`, `InvalidRoute(String)`, `NavigationCancelled`. It
+implements `std::fmt::Display`, `std::error::Error`, `Clone`, `PartialEq`,
+`Eq`, and `Debug`.
+
+**FR-ER-2.** `NavResult<T>` is a public alias for `Result<T, NavError>`.
+
+### 1.6 Utilities
+
+**FR-UT-1.** `is_absolute(path)` returns `true` iff `path` starts with a
+URL scheme (`scheme://...`).
+
+**FR-UT-2.** `join_paths(a, b)` concatenates two path segments,
+collapsing duplicate separators.
+
+**FR-UT-3.** `normalize_path(path)` resolves `.` and `..` segments without
+escaping the root.
+
+**FR-UT-4.** `urlencoding_encode` percent-encodes a string;
+`urlencoding_decode` returns `Option<String>` (`None` on malformed input).
+
+## 2. Non-functional requirements
+
+### 2.1 Compatibility
+
+| Requirement | Value |
+|-------------|-------|
+| MSRV | Rust **1.95+**, enforced by CI's MSRV matrix on Linux/macOS/Windows |
+| Edition | 2024 |
+| Yew | 0.23+ |
+| yew-router | 0.20+ |
+| `no_std` | **Not supported.** The Yew runtime requires `std`; this is a deliberate non-goal documented in CI's `no_std` job. |
+| Browser support | Whatever Yew CSR + `wasm32-unknown-unknown` supports |
+
+### 2.2 Versioning
+
+**NFR-V-1.** The crate adheres to **Semantic Versioning 2.0.0** and to the
+**Cargo `0.x` interpretation**: while the major version is `0`, every
+breaking change increases the minor (`0.x → 0.(x+1)`); additive changes
+increase the patch (`0.x.y → 0.x.(y+1)`).
+
+**NFR-V-2.** Every release is tagged on `main` (`vX.Y.Z`), published to
+`crates.io`, and published as a GitHub release whose body reproduces the
+matching `CHANGELOG.md` section.
+
+**NFR-V-3.** `CHANGELOG.md` follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and is written
+ahead of the merge that tags the release.
+
+### 2.3 Quality gates
+
+**NFR-Q-1.** Every commit on `main` was produced by a PR whose CI passed
+the following gates:
+
+- `cargo +nightly fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery`
+- `cargo nextest run --all-features --profile ci`
+- `cargo test --doc --all-features`
+- `cargo llvm-cov` upload to Codecov
+- `cargo deny check`
+- `cargo audit`
+- `reuse lint`
+- `actionlint`
+- `trunk build --release` against `example/`
+- Lighthouse CI thresholds (perf 0.85, a11y 0.9, best-practices 0.9, SEO 0.9)
+
+**NFR-Q-2.** No `unsafe` blocks in `src/` or `tests/`.
+
+**NFR-Q-3.** No `unwrap()` or `expect()` outside `#[cfg(test)]` in the
+public crate — error handling uses `?`, `Option::map_or_else`,
+`Option::unwrap_or`, etc.
+
+**NFR-Q-4.** Every public item carries a `///` doc comment and a doctest
+where it makes sense.
+
+### 2.4 Accessibility
+
+**NFR-A-1.** Library components emit ARIA attributes appropriate to their
+role: `NavList` carries `role="navigation"` + `aria-label`, `NavTabs` set
+`role="tab"` / `aria-selected` / `aria-controls`, etc.
+
+**NFR-A-2.** The bundled demo (`example/`) honours `prefers-color-scheme:
+dark`, `prefers-reduced-motion: reduce`, ships a skip-to-content link, and
+maintains a visible `:focus-visible` ring across the whole UI.
+
+### 2.5 Security
+
+**NFR-S-1.** Every supply-chain advisory surfaced by `cargo audit` or
+`cargo deny check` blocks the release pipeline. Two `unmaintained` warnings
+on transitive `proc-macro-error` (pulled through `yew-macro`) are
+acknowledged in CI as informational; they do not have a known exploit path.
+
+**NFR-S-2.** Disclosure policy lives in `SECURITY.md`.
+
+### 2.6 Licensing
+
+**NFR-L-1.** The crate is **MIT-licensed**. Every Rust, SCSS, HTML, YAML,
+and Markdown file carries `SPDX-FileCopyrightText` and
+`SPDX-License-Identifier` headers, and `reuse lint` passes in CI.
+
+## 3. Out-of-scope
+
+- Server-side rendering — Yew SSR is supported by yew-router, but
+  `yew-nav-link`'s active-state computation has only been tested under CSR.
+- A custom router — the crate is a *companion* to `yew-router`, not a
+  replacement.
+- Internationalisation of breadcrumb labels — provided by the consumer via
+  `BreadcrumbLabelProvider`.
+- Telemetry / analytics integration.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,84 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Roadmap
+
+Public plan toward stabilising `yew-nav-link` at 1.0. Anything here is a
+target, not a promise; the [GitHub milestones][milestones] track the
+authoritative cutline of each release.
+
+[milestones]: https://github.com/RAprogramm/yew-nav-link/milestones
+
+## 0.9.x — current line (patch series)
+
+**Released.** Status: maintained.
+
+- 0.9.0 dropped the macros feature.
+- 0.9.1 replaced the multi-page demo with a single-file SPA, fixed the
+  `use_breadcrumbs` segment-loop shadow binding, and SPDX-tagged every
+  source file.
+- 0.9.2 surfaced `BreadcrumbLabelProvider` at the crate root.
+- 0.9.3 made `BreadcrumbLabelProviderContext` part of the public API so
+  consumers can actually inject a provider (the trait alone was reachable
+  but inert).
+
+The 0.9.x line continues to receive **patch-level fixes only**: bug fixes,
+documentation, demo, CI, and dependency bumps. No public API changes land
+on 0.9.x.
+
+## 0.10.0 — breaking-change pass
+
+**Target window:** before 1.0 freeze. **Status:** planned.
+
+This is where every accumulated breaking change ships at once, so
+consumers upgrade in a single hop:
+
+- **Drop the unused `route_params.rs` module.** It exists privately,
+  isn't re-exported, and is documented as removed in CHANGELOG. Cleaning
+  it out is a tree-shake, not a feature loss.
+- **Library-level `aria-current="page"` on active `NavLink`.** Today the
+  demo wraps active items in `aria-current` manually. Embedding it in
+  `NavLink` itself fixes accessibility once for every consumer; it
+  changes the rendered HTML, hence the breaking bump.
+- **Tighter MSRV review.** 1.95 was the latest stable when the line was
+  cut; 0.10 will pin to whichever stable Rust ships within the
+  development window.
+- **Audit `prop_or_default` defaults** across components for consistency
+  before they freeze at 1.0.
+
+## 1.0.0 — API freeze
+
+**Target window:** after 0.10 has spent at least one quarter in the
+ecosystem with no API changes. **Status:** dependent on 0.10 feedback.
+
+The 1.0 commitment is small and deliberately boring:
+
+- **Public API freeze.** Every name re-exported from `lib.rs` becomes a
+  semver-stable surface; subsequent breaking changes require a 2.0.
+- **Documented backwards-compatibility window** in `SECURITY.md` and
+  `docs/REQUIREMENTS.md`: how long 1.x receives security patches.
+- **Migration guide** from 0.x in `CHANGELOG.md` for the major bump.
+
+Nothing about 1.0 is meant to be flashy. It is the version we keep
+shipping for years.
+
+## Beyond 1.0 — speculative
+
+Tracked in [GitHub Discussions][discuss], not committed to:
+
+- SSR support: yew-router supports it, but the active-state hooks have
+  not been tested under SSR.
+- Optional `axum-router`-style integration helpers for projects that
+  generate their `Routable` enum from a backend.
+- A standalone `aria-current` consumer hook for projects that build their
+  own link components but want yew-nav-link's matching algorithm.
+
+[discuss]: https://github.com/RAprogramm/yew-nav-link/discussions
+
+## How to influence the roadmap
+
+Open an issue with the `enhancement` label and a clear use case. Concrete,
+narrow proposals beat large redesigns; we will steer toward what existing
+consumers actually need.


### PR DESCRIPTION
Closes #59

## Why

KaiCode 2026 grades **requirements documentation** and **documentation quality** as separate dimensions. Today we have rustdoc + README + CONTRIBUTING + SECURITY + CODE_OF_CONDUCT, but nothing that pins down formal requirements or design rationale, and nothing that says where the project is going next.

## What

Three new files under `docs/`:

| File | Scope |
|------|-------|
| `docs/REQUIREMENTS.md` | Every public surface stated as a numbered functional requirement (`FR-NL-*`, `FR-FN-*`, `FR-HK-*`, `FR-ER-*`, `FR-UT-*`) plus a non-functional section covering compatibility (MSRV 1.95, no_std posture), semver policy, quality gates, accessibility, security, and licensing. Out-of-scope items are listed explicitly so the contract is closed-form. |
| `docs/ARCHITECTURE.md` | Design rationale. Crate-layout invariants, the segment-wise active-state algorithm, the hook contract, the `BreadcrumbLabelProviderContext` newtype + pointer-equality `PartialEq`, and a "what we don't use and why" section (no `unsafe`, no `no_std`, no async, no internal mutability outside the breadcrumb context). |
| `docs/ROADMAP.md` | Public trajectory: 0.9.x (current patch line), 0.10 (one-shot breaking pass: drop `route_params.rs`, library-level `aria-current="page"`, MSRV review), 1.0 (API freeze + supported-versions window), plus speculative beyond-1.0 ideas. |

README gains a **Project documentation** section linking the three new files alongside SECURITY.md and CONTRIBUTING.md so they are discoverable.

## Validation

- `reuse lint` clean (105/105 files compliant — every new doc file has SPDX headers)
- pre-commit (fmt + clippy + deny + audit + actionlint) clean
- All claims in REQUIREMENTS are either currently exercised by tests/demo/CI or explicitly listed as out-of-scope

## Notes

This PR doesn't touch `Cargo.toml`, so the release job will skip on merge.