### PR TITLE
63

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,6 +13,10 @@ SPDX-License-Identifier: MIT
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/styles/github-dark.min.css">
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/highlight.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/languages/rust.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.10.0/build/languages/ini.min.js" defer></script>
     <link data-trunk rel="scss" href="styles/main.scss">
 </head>
 <body>

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -45,17 +45,38 @@ enum Route {
 // DemoCard — the building block: title + description + live preview + code
 // ============================================================================
 
+#[wasm_bindgen]
+extern "C" {
+    /// Re-runs highlight.js across the document. Loaded from CDN in
+    /// `index.html`; we trigger it after Yew has mounted any fresh code
+    /// blocks. Safe to call repeatedly — hljs marks already-highlighted
+    /// nodes with a sentinel class.
+    #[wasm_bindgen(js_namespace = hljs, js_name = highlightAll, catch)]
+    fn highlight_all() -> Result<(), JsValue>;
+}
+
 #[derive(Properties, PartialEq)]
 struct DemoCardProps {
     title:       AttrValue,
     #[prop_or_default]
     description: Option<AttrValue>,
+    /// Optional language hint passed to highlight.js (defaults to `rust`).
+    #[prop_or(AttrValue::Static("rust"))]
+    language:    AttrValue,
     code:        AttrValue,
     children:    Children
 }
 
 #[function_component]
 fn DemoCard(props: &DemoCardProps) -> Html {
+    // Re-highlight on every mount. Cheap; hljs deduplicates internally.
+    use_effect_with(props.code.clone(), |_| {
+        let _ = highlight_all();
+        || ()
+    });
+
+    let code_class = format!("language-{}", props.language);
+
     html! {
         <article class="demo-card">
             <header class="demo-card__head">
@@ -68,7 +89,9 @@ fn DemoCard(props: &DemoCardProps) -> Html {
                 <div class="demo-card__preview" aria-label="Live preview">
                     { for props.children.iter() }
                 </div>
-                <pre class="demo-card__code" aria-label="Source code"><code>{ props.code.clone() }</code></pre>
+                <pre class="demo-card__code" aria-label="Source code">
+                    <code class={code_class}>{ props.code.clone() }</code>
+                </pre>
             </div>
         </article>
     }
@@ -175,6 +198,7 @@ fn HomePage() -> Html {
             >
                 <DemoCard
                     title="Cargo.toml"
+                    language="ini"
                     code={r#"[dependencies]
 yew         = { version = "0.23", features = ["csr"] }
 yew-router  = "0.20"

--- a/example/styles/_components.scss
+++ b/example/styles/_components.scss
@@ -69,6 +69,15 @@
         margin: 0;
         white-space: pre;
         tab-size: 4;
+
+        // highlight.js paints token colours on `<code>` and would otherwise
+        // override our pre-level background and padding. Strip those, keep
+        // colours.
+        & > code.hljs {
+            background: transparent;
+            padding: 0;
+            display: block;
+        }
     }
 }
 


### PR DESCRIPTION
Closes #63

## What

Wire highlight.js into the demo so the code blocks in every \`DemoCard\` get language-aware token colouring instead of single-colour monospace.

## How

- \`example/index.html\` pulls highlight.js + the github-dark theme + the Rust and INI grammars from \`cdn.jsdelivr.net\` with \`defer\`. Stays off the WASM bundle (~30 kB gzipped over the wire).
- \`DemoCard\` gains an optional \`language: AttrValue\` prop (defaults to \`"rust"\`, set to \`"ini"\` for the Cargo.toml card so TOML reads correctly via hljs's INI grammar).
- The \`<code>\` element is tagged with \`language-{lang}\` so hljs picks the grammar without auto-detection.
- A \`use_effect_with(props.code.clone(), ...)\` hook re-runs \`hljs.highlightAll()\` whenever a card is mounted or its code changes. hljs deduplicates internally so the per-card call is safe.
- \`hljs.highlightAll\` is bound through wasm-bindgen as a checked extern (\`Result<(), JsValue>\`); a missing script no-ops rather than panicking.

## SCSS

github-dark paints \`#0d1117\` on \`<code class="hljs">\`, which would override the demo's slab background and padding. Reset background/padding under \`.demo-card__code > code.hljs\` so hljs only owns token colours; the surrounding \`<pre>\` keeps layout responsibility.

## Validation

- \`trunk build --release\` clean
- pre-commit (fmt + clippy + deny + audit + actionlint) clean

## Notes

This PR doesn't change \`Cargo.toml\`, so the release job will skip on merge.