### PR TITLE
65

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -63,6 +63,10 @@ struct DemoCardProps {
     /// Optional language hint passed to highlight.js (defaults to `rust`).
     #[prop_or(AttrValue::Static("rust"))]
     language:    AttrValue,
+    /// When `true` the card stacks preview-then-code so wide components
+    /// (tabs, pagination, dropdown menus) get full card width.
+    #[prop_or(false)]
+    wide:        bool,
     code:        AttrValue,
     children:    Children
 }
@@ -76,9 +80,14 @@ fn DemoCard(props: &DemoCardProps) -> Html {
     });
 
     let code_class = format!("language-{}", props.language);
+    let card_class = if props.wide {
+        "demo-card demo-card--wide"
+    } else {
+        "demo-card"
+    };
 
     html! {
-        <article class="demo-card">
+        <article class={card_class}>
             <header class="demo-card__head">
                 <h3 class="demo-card__title">{ props.title.clone() }</h3>
                 if let Some(desc) = &props.description {
@@ -557,30 +566,41 @@ fn ComponentsPage() -> Html {
             <PageSection title="Dropdown">
                 <DemoCard
                     title="Self-managed open/close"
-                    description="NavDropdown owns its own boolean state — no parent wiring required."
-                    code={r#"<NavDropdown toggle_text="Account">
-    <NavDropdownItem>
-        <NavLink<Route> to={Route::Home}>{ "Profile"  }</NavLink<Route>>
-    </NavDropdownItem>
-    <NavDropdownItem>
-        <NavLink<Route> to={Route::Hooks}>{ "Hooks demo" }</NavLink<Route>>
-    </NavDropdownItem>
-    <NavDropdownDivider />
-    <NavDropdownItem disabled=true>{ "Sign out (disabled)" }</NavDropdownItem>
-</NavDropdown>"#}
+                    description="NavDropdown owns its own boolean state — no parent wiring required. Wrap it in NavList so the rendered <li> sits inside a proper <ul>."
+                    wide=true
+                    code={r#"<NavList>
+    <NavDropdown toggle_text="Account">
+        <NavDropdownItem>
+            <NavLink<Route> to={Route::Home}>{ "Profile"  }</NavLink<Route>>
+        </NavDropdownItem>
+        <NavDropdownItem>
+            <NavLink<Route> to={Route::Hooks}>{ "Hooks demo" }</NavLink<Route>>
+        </NavDropdownItem>
+        <NavDropdownDivider />
+        <NavDropdownItem disabled=true>
+            { "Sign out (disabled)" }
+        </NavDropdownItem>
+    </NavDropdown>
+</NavList>"#}
                 >
-                    <NavDropdown toggle_text="Account">
-                        <NavDropdownItem>
-                            <NavLink<Route> to={Route::Home}>{ "Profile" }</NavLink<Route>>
-                        </NavDropdownItem>
-                        <NavDropdownItem>
-                            <NavLink<Route> to={Route::Hooks}>{ "Hooks demo" }</NavLink<Route>>
-                        </NavDropdownItem>
-                        <NavDropdownDivider />
-                        <NavDropdownItem disabled=true>
-                            { "Sign out (disabled)" }
-                        </NavDropdownItem>
-                    </NavDropdown>
+                    <NavList>
+                        <NavDropdown toggle_text="Account">
+                            <NavDropdownItem>
+                                <NavLink<Route> to={Route::Home}>
+                                    { "Profile" }
+                                </NavLink<Route>>
+                            </NavDropdownItem>
+                            <NavDropdownItem>
+                                <NavLink<Route> to={Route::Hooks}>
+                                    { "Hooks demo" }
+                                </NavLink<Route>>
+                            </NavDropdownItem>
+                            <NavDropdownDivider />
+                            <NavDropdownItem disabled=true>
+                                { "Sign out (disabled)" }
+                            </NavDropdownItem>
+                        </NavDropdown>
+                    </NavList>
                 </DemoCard>
             </PageSection>
 
@@ -588,6 +608,7 @@ fn ComponentsPage() -> Html {
                 <DemoCard
                     title="Controlled tabs"
                     description="Active tab and panel visibility are driven by use_state — yew-nav-link only renders, you decide what's selected."
+                    wide=true
                     code={r#"let active = use_state(|| 0u32);
 
 html! {
@@ -648,6 +669,7 @@ html! {
                         "Current page: {}. The component renders prev/next, first/last, sibling pages, and ellipses.",
                         *current_page
                     ))}
+                    wide=true
                     code={r#"let current_page = use_state(|| 1u32);
 let on_page_change = {
     let current_page = current_page.clone();

--- a/example/styles/_components.scss
+++ b/example/styles/_components.scss
@@ -44,16 +44,30 @@
         }
     }
 
+    // Wide cards stack preview-then-code so wide widgets (tabs,
+    // pagination, dropdowns) get the full card width instead of being
+    // pinched into a 1fr column.
+    &--wide &__body {
+        grid-template-columns: 1fr;
+    }
+
+    // In wide cards, let widgets actually fill the preview so tabs,
+    // pagination, and dropdown lists do not float as content-width
+    // islands inside an oversized container.
+    &--wide &__preview {
+        align-items: stretch;
+    }
+
     &__preview {
         background: var(--bg-soft);
         border: 1px dashed var(--border-strong);
         border-radius: var(--radius-sm);
         padding: 1.5rem;
         display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
+        flex-direction: column;
+        gap: 1rem;
         align-items: flex-start;
-        align-content: flex-start;
+        overflow: visible;
         min-height: 4rem;
     }
 


### PR DESCRIPTION
Closes #65

## Bug

User reported: the Components page looks chaotic. Confirmed:

1. NavTabs + NavTabPanel rendered as sibling flex items in a `flex-wrap: row` preview, so the panel content sat beside the tab strip instead of below it.
2. Tabs / Pagination / Dropdown all rendered inside a 1fr 1fr `demo-card__body`, pinching wide widgets into ~50% of the card width.
3. The bare `NavDropdown` was emitted as `<li class="nav-dropdown">` outside any `<ul>` — invalid HTML.

## Fix

- `DemoCard` gains a `wide: bool` prop. Tabs / Pagination / Dropdown opt in.
- `.demo-card--wide .demo-card__body` switches the grid to a single track so preview goes on top and code drops underneath, full card width.
- `.demo-card--wide .demo-card__preview` switches cross-axis alignment to `stretch` so widgets fill the available width rather than floating as content-width islands.
- `.demo-card__preview` default direction changed from `flex-wrap: row` to `flex-direction: column` with `align-items: flex-start`. Inline groupings (`.inline-row`, `.lab-row`, `.button-row`) keep horizontal layout because they wrap their own children.
- The dropdown demo is now wrapped in `<NavList>` (matches what the rest of the section does and yields valid `<ul><li>` structure).

## Validation

- `trunk build --release` clean
- pre-commit (fmt + clippy + deny + audit + actionlint) clean

## Notes

This PR doesn't change `Cargo.toml`, so the release job will skip on merge.