### PR TITLE
67

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,4 +14,4 @@ yew-router = "0.20"
 yew-nav-link = { path = "../" }
 wasm-bindgen = "0.2"
 gloo-timers = { version = "0.4", features = ["futures"] }
-web-sys = "0.3"
+web-sys = { version = "0.3", features = ["Window", "Location"] }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1152,15 +1152,34 @@ impl BreadcrumbLabelProvider for DemoLabels {
 // App
 // ============================================================================
 
+/// Pages-aware basename detection.
+///
+/// On GitHub Pages the demo lives at `/yew-nav-link/`; under
+/// `trunk serve` it lives at `/`. We read the current pathname once at
+/// app startup and ask yew-router to honour the project subpath when it
+/// is present, so every NavLink / Navigator generates URLs that stay
+/// inside the deployment.
+const PAGES_BASENAME: &str = "/yew-nav-link";
+
+fn detect_basename() -> Option<AttrValue> {
+    let pathname = web_sys::window()?.location().pathname().ok()?;
+    if pathname == PAGES_BASENAME || pathname.starts_with(&format!("{PAGES_BASENAME}/")) {
+        Some(AttrValue::Static(PAGES_BASENAME))
+    } else {
+        None
+    }
+}
+
 #[function_component]
 fn App() -> Html {
     let label_ctx = use_memo((), |()| {
         BreadcrumbLabelProviderContext::new(Rc::new(DemoLabels))
     });
+    let basename = detect_basename();
 
     html! {
         <ContextProvider<BreadcrumbLabelProviderContext> context={(*label_ctx).clone()}>
-            <BrowserRouter>
+            <BrowserRouter basename={basename}>
                 <div class="app-shell">
                     <a class="skip-link" href="#main-content">{ "Skip to content" }</a>
                     <TopNav />


### PR DESCRIPTION
Closes #67

## Bug

The demo lives at \`/yew-nav-link/\` on GitHub Pages but \`<BrowserRouter>\` was mounted with no basename, so every \`<NavLink>\` generated href values relative to the document root (\`/components\`, \`/hooks\`, …). Clicking them navigated the user **out** of the demo. Asset URLs were already fine because trunk's \`--public-url /yew-nav-link/\` rewrites \`<link>\`/\`<script>\` paths in \`index.html\`; the runtime router just was not in on the secret.

## Fix

Detect the project subpath at app startup from \`window.location.pathname\`:

- \`/yew-nav-link\` or \`/yew-nav-link/...\` → \`basename = "/yew-nav-link"\`
- any other pathname (e.g. local \`trunk serve\` at \`/\`) → \`None\`

Pass the result to \`<BrowserRouter basename={...}>\`. yew-router 0.20 strips the trailing slash and prepends the basename to every NavLink href and Navigator push, so the same build works on Pages **and** under \`trunk serve\` without any conditional compilation.

## What changed

- \`example/Cargo.toml\` — turn on \`web-sys\` features \`Window\` and \`Location\`
- \`example/src/lib.rs\` — \`detect_basename()\` and \`<BrowserRouter basename={detect_basename()}>\` in \`App\`

## Validation

- \`cd example && trunk build --release\` clean
- pre-commit (fmt + clippy + deny + audit + actionlint) clean
- The 404.html SPA fallback continues to work because the basename detection is applied **after** GitHub Pages serves \`/yew-nav-link/404.html\`; the SPA boots, reads \`/yew-nav-link/whatever\`, strips the basename, and matches the right route

## Notes

This PR doesn't change \`Cargo.toml\` of the library, so the release job will skip on merge. Pages will redeploy automatically.