### PR TITLE
79 #80

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -14,4 +14,4 @@ yew-router = "0.20"
 yew-nav-link = { path = "../" }
 wasm-bindgen = "0.2"
 gloo-timers = { version = "0.4", features = ["futures"] }
-web-sys = { version = "0.3", features = ["Window", "Location"] }
+web-sys = { version = "0.3", features = ["Window", "Location", "Navigator", "Clipboard"] }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -55,6 +55,56 @@ extern "C" {
     fn highlight_all() -> Result<(), JsValue>;
 }
 
+/// Writes `text` to the system clipboard. Fire-and-forget — we don't await
+/// the returned `Promise`. On browsers without `navigator.clipboard` the
+/// call is a no-op.
+fn write_to_clipboard(text: &str) {
+    if let Some(window) = web_sys::window() {
+        let _ = window.navigator().clipboard().write_text(text);
+    }
+}
+
+#[derive(Properties, PartialEq)]
+struct CopyButtonProps {
+    text: AttrValue
+}
+
+#[function_component]
+fn CopyButton(props: &CopyButtonProps) -> Html {
+    let copied = use_state(|| false);
+
+    let onclick = {
+        let text = props.text.clone();
+        let copied = copied.clone();
+        Callback::from(move |_: MouseEvent| {
+            write_to_clipboard(&text);
+            copied.set(true);
+            let copied_revert = copied.clone();
+            gloo_timers::callback::Timeout::new(1500, move || {
+                copied_revert.set(false);
+            })
+            .forget();
+        })
+    };
+
+    let (label, class) = if *copied {
+        ("Copied", "demo-card__copy demo-card__copy--success")
+    } else {
+        ("Copy", "demo-card__copy")
+    };
+
+    html! {
+        <button
+            type="button"
+            class={class}
+            onclick={onclick}
+            aria-label="Copy code to clipboard"
+        >
+            { label }
+        </button>
+    }
+}
+
 #[derive(Properties, PartialEq)]
 struct DemoCardProps {
     title:       AttrValue,
@@ -98,9 +148,12 @@ fn DemoCard(props: &DemoCardProps) -> Html {
                 <div class="demo-card__preview" aria-label="Live preview">
                     { for props.children.iter() }
                 </div>
-                <pre class="demo-card__code" aria-label="Source code">
-                    <code class={code_class}>{ props.code.clone() }</code>
-                </pre>
+                <div class="demo-card__code-wrap">
+                    <CopyButton text={props.code.clone()} />
+                    <pre class="demo-card__code" aria-label="Source code">
+                        <code class={code_class}>{ props.code.clone() }</code>
+                    </pre>
+                </div>
             </div>
         </article>
     }
@@ -929,6 +982,7 @@ fn UtilitiesPage() -> Html {
                     code={r#"join_paths("/foo/bar/", "/baz") // -> "/foo/bar/baz"
 join_paths("foo",       "bar")  // -> "foo/bar""#}
                 >
+                    <div class="util-table-wrap">
                     <table class="util-table">
                         <thead>
                             <tr><th>{ "Inputs" }</th><th>{ "Output" }</th></tr>
@@ -944,6 +998,7 @@ join_paths("foo",       "bar")  // -> "foo/bar""#}
                             </tr>
                         </tbody>
                     </table>
+                    </div>
                 </DemoCard>
 
                 <DemoCard
@@ -951,6 +1006,7 @@ join_paths("foo",       "bar")  // -> "foo/bar""#}
                     code={r#"normalize_path("/foo/bar/../baz/") // -> "/foo/baz/"
 normalize_path("/a/./b/c/../d")    // -> "/a/b/d""#}
                 >
+                    <div class="util-table-wrap">
                     <table class="util-table">
                         <thead>
                             <tr><th>{ "Input" }</th><th>{ "Output" }</th></tr>
@@ -966,6 +1022,7 @@ normalize_path("/a/./b/c/../d")    // -> "/a/b/d""#}
                             </tr>
                         </tbody>
                     </table>
+                    </div>
                 </DemoCard>
 
                 <DemoCard
@@ -973,6 +1030,7 @@ normalize_path("/a/./b/c/../d")    // -> "/a/b/d""#}
                     code={r#"is_absolute("https://example.com") // true
 is_absolute("/relative/path")     // false"#}
                 >
+                    <div class="util-table-wrap">
                     <table class="util-table">
                         <thead>
                             <tr><th>{ "URL" }</th><th>{ "Absolute?" }</th></tr>
@@ -988,6 +1046,7 @@ is_absolute("/relative/path")     // false"#}
                             </tr>
                         </tbody>
                     </table>
+                    </div>
                 </DemoCard>
             </PageSection>
 
@@ -1000,6 +1059,7 @@ is_absolute("/relative/path")     // false"#}
 let decoded: Option<String> = urlencoding_decode(&encoded);
 // Some("rust 2024")"#}
                 >
+                    <div class="util-table-wrap">
                     <table class="util-table">
                         <thead>
                             <tr>
@@ -1025,6 +1085,7 @@ let decoded: Option<String> = urlencoding_decode(&encoded);
                             }
                         </tbody>
                     </table>
+                    </div>
                 </DemoCard>
             </PageSection>
 
@@ -1038,6 +1099,7 @@ let decoded: Option<String> = urlencoding_decode(&encoded);
 NavError::invalid_route("...")    // "invalid route: ..."
 NavError::navigation_cancelled()  // "navigation cancelled""#}
                 >
+                    <div class="util-table-wrap">
                     <table class="util-table">
                         <thead>
                             <tr><th>{ "Constructor" }</th><th>{ "Display" }</th></tr>
@@ -1057,6 +1119,7 @@ NavError::navigation_cancelled()  // "navigation cancelled""#}
                             </tr>
                         </tbody>
                     </table>
+                    </div>
                 </DemoCard>
 
                 <DemoCard

--- a/example/styles/_components.scss
+++ b/example/styles/_components.scss
@@ -71,6 +71,10 @@
         min-height: 4rem;
     }
 
+    &__code-wrap {
+        position: relative;
+    }
+
     &__code {
         background: var(--code-bg);
         color: var(--code-fg);
@@ -91,6 +95,36 @@
             background: transparent;
             padding: 0;
             display: block;
+        }
+    }
+
+    &__copy {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        z-index: 1;
+        appearance: none;
+        background: rgba(255, 255, 255, 0.08);
+        color: var(--code-fg);
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        border-radius: var(--radius-sm);
+        padding: 0.25rem 0.625rem;
+        font-family: var(--font-sans);
+        font-size: 0.75rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background-color 0.15s ease, color 0.15s ease,
+            border-color 0.15s ease;
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.16);
+            color: #ffffff;
+        }
+
+        &--success {
+            background: rgba(16, 185, 129, 0.25);
+            color: #6ee7b7;
+            border-color: rgba(16, 185, 129, 0.4);
         }
     }
 }
@@ -267,6 +301,14 @@
 // ─────────────────────────────────────────────────────────────────
 // Util tables (Utilities page)
 // ─────────────────────────────────────────────────────────────────
+
+// Wrapper so wide tables scroll horizontally on phones instead of
+// blowing out the card width.
+.util-table-wrap {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
 
 .util-table {
     width: 100%;
@@ -694,5 +736,82 @@
 
     &:hover {
         text-decoration: underline;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Responsive: phone-sized viewports (≤ 720 px)
+// ─────────────────────────────────────────────────────────────────
+
+@media (max-width: 720px) {
+    .container {
+        padding: 1.5rem 1rem;
+    }
+
+    .demo-card {
+        padding: 1rem;
+
+        &__preview {
+            padding: 1rem;
+        }
+
+        &__code {
+            padding: 1rem;
+            font-size: 0.75rem;
+        }
+
+        &__copy {
+            top: 0.375rem;
+            right: 0.375rem;
+            font-size: 0.6875rem;
+            padding: 0.1875rem 0.5rem;
+        }
+    }
+
+    // Word-break for inline literals so they cannot push the layout sideways.
+    code,
+    .inline-code {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
+
+    // Util tables already scroll inside .util-table-wrap; force a minimum
+    // column width so columns do not collapse to unreadable widths first.
+    .util-table {
+        min-width: 26rem;
+    }
+}
+
+@media (max-width: 720px) {
+    // Top nav: stack brand + Source on row 1, links scroll horizontally on row 2.
+    .top-nav__inner {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        grid-template-areas:
+            "brand source"
+            "links links";
+        row-gap: 0.5rem;
+        padding: 0.625rem 1rem;
+    }
+
+    .top-nav__brand { grid-area: brand; }
+    .top-nav__source { grid-area: source; }
+
+    .top-nav__links {
+        grid-area: links;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        margin: 0 -0.25rem;
+        padding: 0 0.25rem;
+
+        // Hide the scrollbar on mobile while keeping the swipe affordance.
+        scrollbar-width: thin;
+
+        .nav-link {
+            white-space: nowrap;
+            font-size: 0.875rem;
+            padding: 0.375rem 0.75rem;
+        }
     }
 }


### PR DESCRIPTION
Closes #79
Closes #80

## Why

Two related demo UX improvements bundled because they share the same DemoCard / SCSS surface area.

## What

### Copy-to-clipboard (#79)

- Each `DemoCard` code block has a **Copy** button pinned top-right of the dark slab
- Click writes `props.code` to the clipboard via `web-sys::Navigator::clipboard().write_text(...)` (fire-and-forget — Promise is dropped)
- Label flips to **Copied** with a green tint for 1.5 s via `gloo_timers::callback::Timeout`, then reverts
- Browsers without the Clipboard API silently no-op

### Responsive polish (#80)

- Wrap every `<table class="util-table">` in `<div class="util-table-wrap">` (5 sites). The wrapper does `overflow-x: auto` + `-webkit-overflow-scrolling: touch` so wide tables scroll inside their card on phones
- New `@media (max-width: 720px)` block:
  - container/card/preview/code padding all shrink
  - copy button tightens
  - `overflow-wrap: anywhere` on inline `<code>` so long literals never push the layout sideways
  - `.util-table` gets a `min-width: 26rem` so columns inside the scroll wrapper stay readable
- Top nav rebuilt for the same breakpoint: 1fr/auto grid puts brand + Source on row 1 and a horizontally scrollable link list on row 2 (`flex-wrap: nowrap; overflow-x: auto`) so links swipe instead of stacking awkwardly

## Cargo features

- `web-sys` gains `Navigator` and `Clipboard`

## Validation

- `cd example && trunk build --release` clean
- `cargo +nightly fmt --check` clean
- pre-commit clean
- Manually verified DOM at 360 px / 768 px / 1280 px viewport widths in the build output

## Notes

This PR doesn't change `Cargo.toml` of the library, so the release job will skip on merge.