### PR TITLE
94

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -92,10 +92,12 @@ logic and accept all required state through props.
 
 ### 1.5 Errors
 
-**FR-ER-1.** `NavError` is a `pub enum` with three variants:
-`RouteNotFound`, `InvalidRoute(String)`, `NavigationCancelled`. It
-implements `std::fmt::Display`, `std::error::Error`, `Clone`, `PartialEq`,
-`Eq`, and `Debug`.
+**FR-ER-1.** `NavError` is a `#[non_exhaustive]` `pub enum`. As of 0.10
+it has three variants: `RouteNotFound`, `InvalidRoute(String)`,
+`NavigationCancelled`. It implements `std::fmt::Display`,
+`std::error::Error`, `Clone`, `PartialEq`, `Eq`, and `Debug`. Future
+minor releases may add new variants without bumping the major version;
+consumer matches must include a `_ =>` arm.
 
 **FR-ER-2.** `NavResult<T>` is a public alias for `Result<T, NavError>`.
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,8 @@
 //!         NavError::RouteNotFound => { /* handle */ }
 //!         NavError::InvalidRoute(msg) => { /* handle */ }
 //!         NavError::NavigationCancelled => { /* handle */ }
+//!         // Required because NavError is non_exhaustive.
+//!         _ => { /* handle future variants */ }
 //!     }
 //! }
 //! ```
@@ -37,8 +39,30 @@ use std::{
 ///
 /// Returned by navigation hooks and helper functions when something
 /// goes wrong while resolving or activating a route.
+///
+/// # Stability
+///
+/// This enum is `#[non_exhaustive]`: future minor releases may add new
+/// variants without bumping the major version. Consumers matching on
+/// `NavError` must include a wildcard arm (`_ =>`) so the match remains
+/// exhaustive across upgrades.
+///
+/// ```rust
+/// use yew_nav_link::NavError;
+///
+/// fn describe(err: &NavError) -> &'static str {
+///     match err {
+///         NavError::RouteNotFound => "missing route",
+///         NavError::InvalidRoute(_) => "bad route",
+///         NavError::NavigationCancelled => "cancelled",
+///         // Required because NavError is non_exhaustive.
+///         _ => "unknown navigation error"
+///     }
+/// }
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use]
+#[non_exhaustive]
 pub enum NavError {
     /// The target route does not match any registered route.
     RouteNotFound,


### PR DESCRIPTION
Closes #94

## What

Add `#[non_exhaustive]` to `NavError` so 1.x can grow new variants under semver-minor without breaking consumers'\'' exhaustive matches.

## Changes

- `src/errors.rs` — `#[non_exhaustive]` on the enum + `# Stability` rustdoc section with a runnable example showing the required wildcard arm
- Module-level doctest gains the `_ => …` arm so it still compiles
- `docs/REQUIREMENTS.md` FR-ER-1 documents the new contract

## Breaking change

Foreign-crate exhaustive matches on `NavError` no longer compile. Migration: add a `_ => /* future variants */` arm. Internal uses are unaffected because `#[non_exhaustive]` only constrains foreign crates.

## Validation

- `cargo test --lib errors::` — 8 pass
- `cargo test --doc` — 33 pass
- pre-commit clean

Bundles into the 0.10.0 breaking-change pass; `Cargo.toml` is **not** bumped in this PR — version bump lands in the consolidated 0.10.0 release PR.