### PR TITLE
96

### DIFF
--- a/src/hooks/route_info/breadcrumbs.rs
+++ b/src/hooks/route_info/breadcrumbs.rs
@@ -18,14 +18,27 @@ pub trait BreadcrumbLabelProvider: Send + Sync {
 /// the default path-as-label behaviour of [`use_breadcrumbs`]. Equality is
 /// pointer-equality on the inner [`Rc`], so re-renders happen only when the
 /// concrete provider value changes.
+///
+/// The inner `Rc` is **not** publicly accessible — construct via
+/// [`BreadcrumbLabelProviderContext::new`] and read with
+/// [`BreadcrumbLabelProviderContext::provider`]. Keeping the field private
+/// lets future versions evolve the representation (e.g. a provider chain or
+/// internal cache) without breaking consumers.
 #[derive(Clone)]
-pub struct BreadcrumbLabelProviderContext(pub Rc<dyn BreadcrumbLabelProvider>);
+pub struct BreadcrumbLabelProviderContext(Rc<dyn BreadcrumbLabelProvider>);
 
 impl BreadcrumbLabelProviderContext {
     /// Wraps the given provider so it can be passed to `ContextProvider`.
     #[must_use]
     pub fn new(provider: Rc<dyn BreadcrumbLabelProvider>) -> Self {
         Self(provider)
+    }
+
+    /// Returns a clone of the inner [`Rc`] for callers that need to invoke
+    /// the provider directly.
+    #[must_use]
+    pub fn provider(&self) -> Rc<dyn BreadcrumbLabelProvider> {
+        Rc::clone(&self.0)
     }
 }
 


### PR DESCRIPTION
Closes #96

## What

Make `BreadcrumbLabelProviderContext`'s inner field private so the type can evolve under semver-minor.

## Changes

- `pub Rc<dyn BreadcrumbLabelProvider>` → `Rc<dyn …>` (private)
- New `provider(&self) -> Rc<dyn BreadcrumbLabelProvider>` accessor for read-only access (returns an `Rc` clone)
- `::new()` constructor unchanged
- Rustdoc updated to direct callers to the new pair

## Breaking change

| Was | Now |
|---|---|
| `BreadcrumbLabelProviderContext(rc)` | `BreadcrumbLabelProviderContext::new(rc)` |
| `ctx.0` | `ctx.provider()` |

Internal uses (impl PartialEq, use_breadcrumbs hook) continue working — same-module visibility is unaffected by removing `pub` from the field.

## Validation

- `cargo test --lib breadcrumbs::` — 27 pass
- `cargo test --doc` — 33 pass
- `cd example && trunk build --release` clean

## Notes

`Cargo.toml` is **not** bumped here. Bundles into the consolidated 0.10.0 release PR alongside other breaking changes.