### PR TITLE
104

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Scorecard
+
+# OSSF Scorecard scans supply-chain posture (branch protection, signed
+# releases, dependency pinning, code review, etc.). Runs weekly so the
+# published score reflects the current main; running on push to main keeps
+# the public dashboard fresh between cron runs.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 4 * * 1"
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: scorecard-results.sarif

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Enterprise-grade navigation library for [Yew](https://yew.rs) — automatic acti
 [![MSRV](https://img.shields.io/crates/msrv/yew-nav-link)](https://crates.io/crates/yew-nav-link)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![REUSE](https://api.reuse.software/badge/github.com/RAprogramm/yew-nav-link)](https://api.reuse.software/info/github.com/RAprogramm/yew-nav-link)
+[![OSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/RAprogramm/yew-nav-link/badge)](https://securityscorecards.dev/viewer/?uri=github.com/RAprogramm/yew-nav-link)
 [![Codecov](https://codecov.io/gh/RAprogramm/yew-nav-link/branch/main/graph/badge.svg)](https://codecov.io/gh/RAprogramm/yew-nav-link)
 
 </div>


### PR DESCRIPTION
Closes #104

Adds OSSF Scorecard analysis (weekly cron + push to main) that publishes a public score for the repo's supply-chain posture and uploads SARIF to GitHub Code Scanning. Adds the dynamic badge to README.

actionlint clean.