### PR TITLE
116

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,12 @@ git commit -m "#123 feat: add custom class support"
 - **Reviews:** there is no required-reviewer rule on `main`, but every PR
   must pass the `CI Success` aggregate status check before merge — that's
   enforced by branch protection.
-- **Merge style:** rebase. We keep `main` linear; force-pushes to `main`
-  and branch deletion are blocked.
+- **Merge style:** squash, with branch auto-deleted on merge. The PR title
+  becomes the conventional-commit subject on `main`; the PR body becomes the
+  commit message body. We keep `main` linear; force-pushes to `main` and
+  branch deletion are blocked. Rebase merge stays allowed for the rare case
+  where intermediate commits carry independent value. See
+  [`docs/BRANCHING.md`](docs/BRANCHING.md) for the full policy.
 
 ## Code standards
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ pub struct BreadcrumbItem {
 | [`docs/REQUIREMENTS.md`](docs/REQUIREMENTS.md) | Functional and non-functional requirements (what the crate does, the constraints under which it does it) |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Module layout, the active-state algorithm, hook contracts, breadcrumb context flow |
 | [`docs/ROADMAP.md`](docs/ROADMAP.md) | Trajectory toward 0.10 (breaking-change pass) and 1.0 (API freeze) |
+| [`docs/BRANCHING.md`](docs/BRANCHING.md) | Branching, commit, and merge policy enforced on `main` |
 | [`SECURITY.md`](SECURITY.md) | Coordinated disclosure policy |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Workflow, commit format, code standards |
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,139 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Branching and merge policy
+
+This document is the source of truth for how changes reach `main`. It
+codifies what `.github/settings.yml` enforces at the GitHub layer and how
+`CONTRIBUTING.md` instructs contributors to interact with it.
+
+## 1. The default branch
+
+`main` is the only long-lived branch. Every release ships from it.
+
+Protection rules (set by `.github/settings.yml`):
+
+| Rule | Value |
+|---|---|
+| Required status check | `CI Success` (aggregate of every job in `.github/workflows/ci.yml`) |
+| Strict status checks | yes — PR must be up to date with `main` |
+| Linear history | yes — no merge commits |
+| Force pushes | blocked |
+| Branch deletion | blocked |
+| Approving reviews required | 1 (CODEOWNERS) |
+| Stale review dismissal | yes |
+
+There is no `develop`, no `release/*`, no `hotfix/*`. Earlier versions of
+`settings.yml` mention a `develop` branch; that is legacy configuration and
+is not used in practice.
+
+## 2. Feature branches
+
+One branch per GitHub issue, named after the issue number:
+
+```bash
+git checkout -b 123
+```
+
+No prefixes (`feat/`, `feature/`, `bugfix/`), no descriptive slugs. The
+issue is the source of truth for what the branch is about; the title and
+body of the PR carry the human-readable framing.
+
+A branch may carry multiple commits — the squash-merge collapses them into
+a single line on `main`. Keep commits small and focused; rebase locally to
+clean up before pushing if needed.
+
+## 3. Commit format
+
+Every commit message starts with the issue reference and a conventional
+commit prefix:
+
+```
+#<issue> <type>: <description>
+```
+
+The prefixes feed `cliff.toml` and decide which CHANGELOG section the
+commit lands in:
+
+| Prefix | CHANGELOG section | Triggers minor/patch bump under release-plz |
+|---|---|---|
+| `feat` | Features | minor |
+| `fix` | Bug Fixes | patch |
+| `docs` | Documentation | patch |
+| `refactor` | Refactoring | patch |
+| `ci` | CI | patch |
+| `deps`, `chore(deps)` | Dependencies | patch |
+| `test` | (skipped) | none |
+| `chore` | (skipped) | none |
+
+Breaking changes carry a `!` after the type (`feat!:`, `refactor!:`) and
+trigger a major bump.
+
+## 4. Merge style
+
+**Squash merge, delete branch.** Configured in `.github/settings.yml`:
+
+```yaml
+allow_squash_merge: true
+allow_merge_commit: false
+allow_rebase_merge: true
+delete_branch_on_merge: true
+squash_merge_commit_title: PR_TITLE
+squash_merge_commit_message: PR_BODY
+```
+
+Rebase merge is allowed for the rare case where individual intermediate
+commits carry value on their own (e.g. a sequence of independent refactors
+that should be bisectable). Default is squash: one PR = one commit on
+`main`, with the PR title becoming the conventional-commit subject and the
+PR body becoming the commit message.
+
+Force pushes to `main` are blocked at the GitHub layer; this is not a
+convention, it is a hard wall.
+
+## 5. Pull request
+
+| Field | Requirement |
+|---|---|
+| Title | Issue number only (e.g. `123`). The squash commit subject inherits this. |
+| Body | Must include `Closes #123` so the issue auto-closes on merge. |
+| Status checks | `CI Success` must be green. |
+| Reviews | 1 approving review from a `CODEOWNERS` entry (currently `@RAprogramm`). |
+| Up-to-date | Strict mode is on — rebase onto `main` if it has advanced since CI ran. |
+
+The PR body is what readers of the commit history will see on `main`, so
+write it for that audience, not just the reviewer.
+
+## 6. Reverting
+
+A bad change is rolled back with a revert PR, never with a force-push or
+history rewrite:
+
+```bash
+git revert <sha>
+git checkout -b <new-issue>
+git push -u origin <new-issue>
+gh pr create --title "<new-issue>" --body "Closes #<new-issue>"
+```
+
+The revert commit follows the same `#<issue> revert: <description>` form,
+and the new issue documents *why* the original change was rolled back.
+
+## 7. Releases
+
+Releases happen on `main`. There is no release branch.
+
+The bump → publish flow is documented in [`RELEASE.md`](../RELEASE.md). In
+short: a release PR (today hand-edited, eventually opened by `release-plz`)
+bumps `Cargo.toml` `version` and prepends a section to `CHANGELOG.md`;
+merging it triggers the publish job. Every release tag is annotated and
+signed.
+
+## 8. References
+
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — full contributor workflow.
+- [`RELEASE.md`](../RELEASE.md) — release procedure.
+- [`.github/settings.yml`](../.github/settings.yml) — enforced settings.
+- [`cliff.toml`](../cliff.toml) — conventional commit → CHANGELOG mapping.


### PR DESCRIPTION
Closes #116

## Summary

- New `docs/BRANCHING.md` codifying what `.github/settings.yml` enforces: `main` is the only long-lived branch, linear history, squash-merge with branch auto-delete, feature branches named by issue number, conventional commit prefixes mapped to CHANGELOG sections per `cliff.toml`, revert-PR rollback policy.
- `CONTRIBUTING.md` "Open a pull request" section: `Merge style: rebase` → `Merge style: squash` (rebase still allowed for the rare case where intermediate commits carry value), now points at the new policy doc for the full picture.
- `README.md` "Project documentation" table gets a row for `docs/BRANCHING.md`.

Real `main` history is squash-merged conventional commits per issue (`#102`, `#104`, `#106`, `#108`, `#110`), so this PR aligns the docs with practice rather than changing practice.

## Test plan

- [x] `reuse lint` — green, every new file SPDX-tagged
- [x] `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green
- [x] No code touched, no public API affected, no CHANGELOG hand-edit (Unreleased is refreshed weekly by `changelog-refresh.yml`)
- [ ] `CI Success` aggregate green