### PR TITLE
115

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,10 @@ yew-nav-link
 └── errors            # NavError, NavResult types
 ```
 
-See the source code and inline documentation for detailed design documentation.
+For *why* the crate is shaped this way — the trade-offs picked over each
+alternative — see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the
+overview and [`docs/adr/`](docs/adr/) for individual architecture
+decision records.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,3 +157,20 @@ component, hook, and utility appears in at least one card whose live
 preview is rendered side-by-side with the exact Rust snippet that
 produces it. The breadcrumb label provider is mounted at the top of the
 tree so `use_breadcrumbs` has a real provider to read.
+
+## 8. Decision history
+
+This document is intentionally short on *why*. The reasoning behind each
+non-trivial design choice lives in the
+[Architecture Decision Records](adr/), one per file in MADR format.
+
+| Decision | ADR |
+|---|---|
+| `class` / `active_class` use `&'static str`, not `AttrValue` | [0001](adr/0001-static-str-classes.md) |
+| The `macros` feature was dropped in 0.9.0 | [0002](adr/0002-drop-macros-feature.md) |
+| `NavError` is `#[non_exhaustive]` from 0.10.0 | [0003](adr/0003-non-exhaustive-nav-error.md) |
+| `NavLink` renders a manual `<a>` instead of wrapping `yew_router::Link` | [0004](adr/0004-manual-anchor-over-yew-router-link.md) |
+| Active links emit `aria-current="page"` | [0005](adr/0005-active-state-via-aria-current.md) |
+
+New non-trivial decisions land as new ADRs; this table is updated in the
+same PR.

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -1,0 +1,60 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# 0000 — Record architecture decisions
+
+- **Status:** accepted
+- **Date:** 2026-05-12
+- **Deciders:** RAprogramm
+
+## Context
+
+`docs/ARCHITECTURE.md` describes the *current* shape of the crate. It is
+silent on *why* that shape was chosen, on what alternatives were rejected,
+and on what would have to change for the decision to be revisited.
+Reviewers (KaiCode jurors among them) reading the source can see the
+result, not the reasoning. The reasoning lives in PR descriptions, git
+history, and the maintainer's head — three places that decay differently
+and none of which the casual reader will dig through.
+
+## Decision
+
+Maintain an Architecture Decision Record log in `docs/adr/`, one
+decision per file, using the [MADR][madr] template.
+
+Each ADR carries:
+
+- A numeric, monotonically increasing ID (`0001-`, `0002-`, …) baked into
+  the filename so cross-references survive renames.
+- A status (`proposed`, `accepted`, `superseded by NNNN`, `deprecated`).
+- The context that made the decision necessary.
+- The decision itself, in declarative form.
+- The consequences — positive, negative, and what it costs to reverse.
+
+ADRs are written when the decision is made, not retrofitted later. The
+opening batch (0001–0005) is the exception: it documents decisions that
+shaped the 0.9/0.10 cycle and would otherwise stay implicit.
+
+[madr]: https://adr.github.io/madr/
+
+## Consequences
+
+**Positive**
+
+- `docs/ARCHITECTURE.md` becomes a living overview that links to the ADR
+  log instead of trying to encode rationale inline.
+- New contributors can see why a constraint exists before proposing to
+  break it.
+- Breaking changes carry an ADR — the ROADMAP entry becomes one line
+  pointing at the ADR for the *why*.
+
+**Negative**
+
+- One more place to write to when shipping a non-trivial change.
+  Mitigated by keeping ADRs short — a single screen is the target.
+
+**Cost to reverse**
+
+Low. ADRs are markdown files; removing them does not change any code.

--- a/docs/adr/0001-static-str-classes.md
+++ b/docs/adr/0001-static-str-classes.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# 0001 — `class` and `active_class` are `&'static str`
+
+- **Status:** accepted
+- **Date:** 2026-05-12
+- **Deciders:** RAprogramm
+
+## Context
+
+`NavLinkProps` exposes two CSS-class slots:
+
+```rust
+#[prop_or("nav-link")]
+pub class: &'static str,
+
+#[prop_or("active")]
+pub active_class: &'static str,
+```
+
+The natural alternatives in the Yew ecosystem are `AttrValue` (an
+internally `Rc<str>`-backed handle used by attribute values) and
+`Classes` (an internal `Vec<AttrValue>` with deduplication and lazy
+join). Both accept runtime-built strings; `&'static str` does not.
+
+The question is whether the cost of `&'static str` — consumers cannot
+pass an interpolated class list — outweighs the cost of the alternatives:
+an allocation on every render, a deeper trait stack, and a less obvious
+"what is this argument" answer for newcomers.
+
+## Decision
+
+Keep `&'static str` for both class slots.
+
+The crate's contract is that class slots configure the wrapper. A
+consumer who needs runtime classes composes them on the parent element
+or via a tailwind/CSS-in-JS layer, not by funnelling a `format!("{}{}",
+…)` through `NavLink`. The 99% case is a literal class name; making
+literals zero-cost is the right trade.
+
+For the breadcrumb chain and other components where class composition is
+unavoidable, those props use `Classes` directly. The asymmetry is
+deliberate: `NavLink` is the hot path, breadcrumbs are not.
+
+## Consequences
+
+**Positive**
+
+- Zero allocation per render for the common case.
+- Compile-time enforcement that class names are constants — a `String`
+  built from user input cannot land in a CSS class slot, eliminating a
+  class of HTML-injection footguns at the type level.
+- `NavLinkProps: Copy`-ish: every field is trivially clonable, making
+  `#[derive(Clone, PartialEq)]` cheap.
+
+**Negative**
+
+- A consumer who needs runtime class composition on `NavLink`
+  specifically cannot do it through the prop. They must either lift the
+  class to the parent or wrap `NavLink` in their own component.
+- The breadcrumb-vs-NavLink asymmetry is a small surprise for new
+  readers and is documented in `docs/ARCHITECTURE.md`.
+
+**Cost to reverse**
+
+Moderate. Switching to `AttrValue` is a semver-breaking signature change
+across the public props of `NavLink`. The internal `build_class` helper
+would also need to grow an allocation path. No data migration; consumer
+upgrade is one-line per call site.

--- a/docs/adr/0002-drop-macros-feature.md
+++ b/docs/adr/0002-drop-macros-feature.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# 0002 — Drop the `macros` feature in 0.9.0
+
+- **Status:** accepted
+- **Date:** 2026-04-16
+- **Deciders:** RAprogramm
+
+## Context
+
+Versions 0.1 – 0.8 shipped a proc-macro crate (`yew-nav-link-macros`)
+behind a `macros` feature flag. It offered a `nav_link!()` declarative
+macro that expanded to the same `NavLink` invocation that the function
+syntax (`nav_link(...)`) already produced.
+
+The macro existed for one reason: callers who wanted to spell the link
+inline (`html! { nav_link!(Route::Home, "Home") }`) without an extra
+`{ }` around the function call. That ergonomic gain came with a
+disproportionate maintenance tail:
+
+- A whole proc-macro crate (build-script, separate `Cargo.toml`,
+  separate publish step) for what compiled down to one line of code.
+- Trybuild tests for the macro's diagnostic messages — flaky across
+  toolchain versions, and yet another CI matrix to maintain.
+- A second documented API surface every contributor had to keep in
+  sync with the function and component syntaxes.
+- A feature flag that almost no public consumer enabled (visible from
+  reverse-deps on crates.io at the time of the decision).
+
+## Decision
+
+Remove the `macros` feature and the `yew-nav-link-macros` sub-crate in
+0.9.0. Keep both the component syntax (`<NavLink<R> ...>`) and the
+function syntax (`nav_link(Route::Home, "Home", Match::Exact)`).
+
+`nav_link()` is the de facto replacement for the macro: it composes
+into `html! { }` without extra braces (`html! { { nav_link(...) } }`
+becomes `html! { nav_link(...) }` because `Html` implements the
+necessary conversions inline).
+
+## Consequences
+
+**Positive**
+
+- One less crate to publish, one less feature matrix to test, one
+  less proc-macro to debug across compiler upgrades.
+- The two remaining APIs (component, function) are clearly differentiated:
+  component when you need props, function when you need an inline
+  expression.
+- MSRV bumps and Yew bumps land faster because there is no proc-macro
+  layer to chase.
+
+**Negative**
+
+- A breaking change for consumers who had enabled `macros`. Migration
+  is mechanical: `nav_link!(R, "x")` → `nav_link(R, "x", Match::Exact)`.
+- One historical convenience is gone.
+
+**Cost to reverse**
+
+High. The proc-macro crate would have to be re-published from scratch
+with its own version history, and the feature flag re-introduced. We do
+not expect to reverse.
+
+## References
+
+- CHANGELOG `[0.9.0]` — "Macros feature removed".
+- ROADMAP `0.10.0 — breaking-change pass`.

--- a/docs/adr/0003-non-exhaustive-nav-error.md
+++ b/docs/adr/0003-non-exhaustive-nav-error.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# 0003 — `NavError` is `#[non_exhaustive]` from 0.10.0
+
+- **Status:** accepted
+- **Date:** 2026-05-10
+- **Deciders:** RAprogramm
+
+## Context
+
+`NavError` carries the failure cases the navigation layer surfaces to
+consumers:
+
+```rust
+pub enum NavError {
+    RouteNotFound,
+    InvalidRoute(String),
+    NavigationCancelled,
+}
+```
+
+Through 0.9.x the enum was plain — consumers could write exhaustive
+`match` expressions without a wildcard arm. Pleasant in the short term;
+a semver bear-trap in the long term, because *adding* a variant is then
+a breaking change.
+
+The ROADMAP slates several future variants: redirect cancellation
+distinct from generic cancellation, permission-denied (when the consumer
+wires up a route guard), timeout. Each addition under plain enum
+semantics would force a major bump.
+
+## Decision
+
+Mark `NavError` `#[non_exhaustive]` as part of the 0.10.0 breaking-change
+pass.
+
+```rust
+#[non_exhaustive]
+pub enum NavError {
+    RouteNotFound,
+    InvalidRoute(String),
+    NavigationCancelled,
+}
+```
+
+Foreign-crate exhaustive matches must add a wildcard `_ =>`. Internal
+matches inside `yew-nav-link` are unaffected — `#[non_exhaustive]` does
+not apply within the defining crate.
+
+## Consequences
+
+**Positive**
+
+- New variants ship under semver-minor bumps. No further major bumps for
+  this reason alone.
+- Forces consumers to confront the "what if a new error appears"
+  question at compile time, which is the right place for it.
+
+**Negative**
+
+- One-time mechanical migration for every consumer that exhaustively
+  matched `NavError`. The compiler points exactly at the missing arm.
+- Wildcard arms can hide forgotten handling. Mitigated by recommending
+  `_ => unreachable!("unknown NavError variant: {err:?}")` for
+  developer-built handlers that want loud failures.
+
+**Cost to reverse**
+
+High. Dropping `#[non_exhaustive]` is itself a non-trivial change:
+consumers may rely on it to keep their wildcard arms exhaustive-by-fiat,
+and removing it would be a semver-minor that *enables* exhaustive
+matching but does not require it. We do not expect to reverse.
+
+## References
+
+- `src/errors.rs:65` — the `#[non_exhaustive]` attribute.
+- CHANGELOG `[0.10.0]` — "Breaking changes".

--- a/docs/adr/0004-manual-anchor-over-yew-router-link.md
+++ b/docs/adr/0004-manual-anchor-over-yew-router-link.md
@@ -1,0 +1,76 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# 0004 — Render a manual `<a>` instead of wrapping `yew_router::Link`
+
+- **Status:** accepted
+- **Date:** 2026-05-10
+- **Deciders:** RAprogramm
+
+## Context
+
+Through 0.9.x `NavLink` was a thin wrapper around `yew_router::Link`. The
+wrapper computed the active state, then handed off rendering to `Link`,
+which produced the `<a>` element and intercepted clicks.
+
+Two needs piled up against this layering:
+
+1. **Attribute control.** Active links should emit `aria-current="page"`
+   (ADR 0005), and the rendered set of attributes should be fully under
+   our control for future additions (e.g. `data-active`, custom event
+   handlers, `download` for export links). `yew_router::Link` does not
+   expose hooks for the attribute set it renders.
+2. **Basename handling for sub-path deployments.** The demo deploys at
+   `https://raprogramm.github.io/yew-nav-link/`, i.e. under a non-empty
+   basename. `Link` renders `href` from `to.to_path()` directly, which
+   produces visually wrong hrefs on hover (`/about` instead of
+   `/yew-nav-link/about`). The demo worked around this with a runtime
+   `<base>` hack — fragile and only addresses the symptom on that one
+   site.
+
+## Decision
+
+From 0.10.0, render the `<a>` manually:
+
+- `href` is built from `to.to_path()` prepended with the navigator's
+  basename when present.
+- An `onclick` handler intercepts left-clicks (and only left-clicks —
+  modifier-clicks fall through to the browser for "open in new tab")
+  and pushes the route via the captured `Navigator`.
+- The full attribute set is under the component's control.
+
+Modifier-click behaviour matches `Link` exactly: `meta`, `ctrl`, `shift`,
+`alt`, and middle-click skip `prevent_default` so the browser takes the
+default route (new tab, save target, etc.).
+
+## Consequences
+
+**Positive**
+
+- Correct `href` under any basename, with no runtime workaround.
+- `aria-current="page"` lands on active links (ADR 0005).
+- Future attribute additions are a one-line change inside `NavLink`'s
+  `html!` instead of a router-layer feature request.
+- One fewer indirection in the render tree.
+
+**Negative**
+
+- We now own a small navigation-affordance contract that `yew_router`
+  used to maintain. If `yew_router` changes how `Navigator::push`
+  interacts with the browser's `popstate`, we need to track that.
+  Mitigated by exhaustive integration tests (issue #113, #114).
+- The wrapper grows from ~10 lines to ~50. Acceptable: the additional
+  lines are intent-revealing.
+
+**Cost to reverse**
+
+Low. Reverting to a `Link` wrapper is a localised change in
+`src/active_link/nav_link.rs`. Consumer-visible behaviour for the
+non-basename case is identical, so a revert ships as a patch release.
+
+## References
+
+- `src/active_link/nav_link.rs` — the manual implementation.
+- CHANGELOG `[0.10.0]` — "Changed: NavLink is rendered as a manual `<a>`".

--- a/docs/adr/0005-active-state-via-aria-current.md
+++ b/docs/adr/0005-active-state-via-aria-current.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# 0005 — Active `NavLink` emits `aria-current="page"`
+
+- **Status:** accepted
+- **Date:** 2026-05-10
+- **Deciders:** RAprogramm
+
+## Context
+
+Through 0.9.x, active `NavLink`s were distinguished by a CSS class only
+(`active` by default, overridable via `active_class`). This is enough
+for sighted users — the visual state is conveyed by stylesheet — and
+zero for assistive technology, which has no semantic signal that one of
+the links in a navigation list is the current page.
+
+The web platform has a dedicated answer:
+[`aria-current`][aria-current]. The value `"page"` declares that the
+link points at the current document; screen readers (NVDA, VoiceOver,
+JAWS) announce it as "current page" or equivalent. This is the WAI-ARIA
+authoring guideline for navigation menus.
+
+[aria-current]: https://www.w3.org/TR/wai-aria-1.2/#aria-current
+
+## Decision
+
+Active `NavLink`s emit `aria-current="page"` in addition to the active
+class:
+
+```rust
+let aria_current = if is_active { Some("page") } else { None };
+html! { <a class={class} href={href} aria-current={aria_current} ...> }
+```
+
+The attribute is omitted entirely (not set to a falsy value) when the
+link is inactive, so the rendered DOM is minimal on non-current links.
+
+## Consequences
+
+**Positive**
+
+- Screen readers correctly identify the current page in navigation menus.
+- CSS authors get a second hook for active-state styling that does not
+  depend on the class name configuration — `[aria-current="page"] { … }`
+  works regardless of whether the consumer overrode `active_class`.
+- Aligns with WAI-ARIA Authoring Practices for navigation patterns;
+  Lighthouse accessibility audits credit the attribute.
+
+**Negative**
+
+- Behaviour change in the rendered DOM. Consumers whose existing CSS
+  *only* targets `.active` continue to work. Consumers whose CSS
+  matched `[aria-current]` for unrelated reasons may see new matches.
+  Documented in CHANGELOG `[0.10.0]` under "Breaking changes" so the
+  surprise is visible.
+- A small amount of attribute churn during re-renders. Negligible —
+  Yew's DOM diffing handles the toggle cleanly.
+
+**Cost to reverse**
+
+Low. Dropping the attribute is a one-line change. We do not expect to
+reverse because the standard is clear and the accessibility benefit is
+unconditional.
+
+## References
+
+- ADR 0004 — Manual `<a>` rendering enabled this attribute addition.
+- `src/active_link/nav_link.rs` — the `aria_current` binding.
+- CHANGELOG `[0.10.0]` — under "Breaking changes" and "Added".

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,36 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Architecture Decision Records
+
+Each non-trivial design decision in `yew-nav-link` is captured as a
+short [MADR][madr]-style document. Decisions are append-only — a record
+is never edited after its status moves to `accepted`. Reversals are
+expressed as new ADRs that mark the prior record `superseded by NNNN`.
+
+[madr]: https://adr.github.io/madr/
+
+## Index
+
+| ID | Title | Status |
+|---|---|---|
+| [0000](0000-record-architecture-decisions.md) | Record architecture decisions | accepted |
+| [0001](0001-static-str-classes.md) | `class` and `active_class` are `&'static str` | accepted |
+| [0002](0002-drop-macros-feature.md) | Drop the `macros` feature in 0.9.0 | accepted |
+| [0003](0003-non-exhaustive-nav-error.md) | `NavError` is `#[non_exhaustive]` from 0.10.0 | accepted |
+| [0004](0004-manual-anchor-over-yew-router-link.md) | Render a manual `<a>` instead of wrapping `yew_router::Link` | accepted |
+| [0005](0005-active-state-via-aria-current.md) | Active `NavLink` emits `aria-current="page"` | accepted |
+
+## When to write an ADR
+
+Write one when the answer to "why is it this way" is non-obvious and
+would not be derivable from reading the code alone. Renaming a field is
+not an ADR. Choosing `&'static str` over `AttrValue` is an ADR.
+
+## Template
+
+Copy `0000-record-architecture-decisions.md` as a starting point. Keep
+each record to roughly one screen — context, decision, consequences. The
+goal is to read fast and rot slowly.


### PR DESCRIPTION
Closes #115

## Summary

- `docs/adr/` with seven files: meta-ADR (`0000`) and five decisions covering 0.9 → 0.10 (`0001` static-str classes, `0002` macros-feature removal, `0003` non-exhaustive `NavError`, `0004` manual `<a>`, `0005` `aria-current="page"`), plus a `README.md` index.
- `docs/ARCHITECTURE.md` gets a new `§8 Decision history` table pointing at each ADR. The doc stays short on *why*; the ADRs are where reasoning lives.
- `README.md` Architecture section updated to point at both `ARCHITECTURE.md` and `docs/adr/` instead of saying "read the source".

ADRs follow [MADR](https://adr.github.io/madr/): status, context, decision, consequences, cost-to-reverse. They are append-only — reversals become new ADRs marking the prior record `superseded by NNNN`.

## Test plan

- [x] `reuse lint` — 120/120 files SPDX-tagged, green
- [x] `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green
- [x] No code touched, no public API affected
- [x] `CHANGELOG.md` `[Unreleased]` will be refreshed by `changelog-refresh.yml` from the `docs:` commit
- [ ] `CI Success` aggregate green