### PR TITLE
119

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,25 @@ jobs:
       - name: Run cargo-audit
         run: cargo audit
 
+      - name: Install cargo-machete
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+
+      - name: Run cargo-machete
+        run: cargo machete
+
+      - name: Setup nightly Rust toolchain for cargo-udeps
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-udeps
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps
+
+      - name: Run cargo-udeps
+        run: cargo +nightly udeps --all-targets --all-features
+
   reuse:
     name: REUSE Compliance
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ exclude = ["example/**"]
 [package.metadata.docs.rs]
 all-features = true
 
+# cargo-udeps cannot detect usage of crates that participate only through
+# proc-macro attributes (`#[wasm_bindgen_test]`) under non-native targets.
+# `wasm-bindgen-test` is exercised by `wasm-pack test` in the dedicated CI
+# job and is genuinely required there.
+[package.metadata.cargo-udeps.ignore]
+development = ["wasm-bindgen-test"]
+
 [features]
 default = []
 


### PR DESCRIPTION
Closes #119

## Summary

- `Security` job in `.github/workflows/ci.yml` gains four new steps after `cargo-audit`: install + run `cargo-machete`, then install nightly toolchain + install + run `cargo-udeps --all-targets --all-features`.
- `Cargo.toml` gets `package.metadata.cargo-udeps.ignore` for `wasm-bindgen-test`, with an inline comment explaining why: udeps cannot detect crates that participate only via `#[wasm_bindgen_test]` proc-macro attribute under non-native targets. `wasm-pack test` (issue #113) exercises the dep for real.

Closes the "unused-deps detection" gap relative to KaiCode's "static analysis" dimension. `deny` controls licences/advisories, `audit` catches CVEs, machete+udeps now cover the third axis: declared-but-unused.

## Local verification

- `cargo machete` — green, no unused declared dependencies
- `cargo +nightly udeps --all-targets --all-features` — `All deps seem to have been used`, with the documented ignore in effect
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] `Security` job runs both new tools and stays green
- [ ] `CI Success` aggregate green