### PR TITLE
117

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,33 @@ jobs:
         run: |
           RUSTDOCFLAGS="-D warnings" cargo doc --all-features
 
+  semver_checks:
+    name: Semver Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Load cached target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: semver-checks
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+
+      - name: Compare public API against the last crates.io release
+        run: cargo semver-checks check-release --verbose
+
   no_std:
     name: no-std
     runs-on: ubuntu-latest
@@ -559,7 +586,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [msrv, check, fmt, docs, no_std, security, reuse, test, coverage, benchmarks, wasm-build, lighthouse, changelog, actionlint, release]
+    needs: [msrv, check, fmt, docs, semver_checks, no_std, security, reuse, test, coverage, benchmarks, wasm-build, lighthouse, changelog, actionlint, release]
     if: always()
     steps:
       - name: Check job status
@@ -570,6 +597,7 @@ jobs:
           echo "  Check: ${{ needs.check.result }}"
           echo "  Format: ${{ needs.fmt.result }}"
           echo "  Docs: ${{ needs.docs.result }}"
+          echo "  Semver Checks: ${{ needs.semver_checks.result }}"
           echo "  no-std: ${{ needs.no_std.result }}"
           echo "  Security: ${{ needs.security.result }}"
           echo "  REUSE: ${{ needs.reuse.result }}"
@@ -582,7 +610,7 @@ jobs:
           echo "  Actionlint: ${{ needs.actionlint.result }}"
           echo "  Release: ${{ needs.release.result }}"
 
-          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || ("${{ needs.release.result }}" != "success" && "${{ needs.release.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
+          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || ("${{ needs.release.result }}" != "success" && "${{ needs.release.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
             echo "❌ CI failed"
             exit 1
           fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,7 +51,14 @@ After 1.0 the standard major/minor/patch rules apply.
 
 6. **Open a PR**, wait for `CI Success` to pass.
 
-7. **Rebase-merge to `main`.** That push triggers the `release` job in
+   The `Semver Checks` job runs `cargo semver-checks check-release`
+   against the previously-published crates.io version. If your changes
+   touch the public API in a way that does not match the version bump
+   in step 3, this job fails — re-decide the version (a wider bump or
+   smaller change) and make the PR consistent. Update both directions
+   here, never bypass the gate with `--allow-...` flags.
+
+7. **Squash-merge to `main`.** That push triggers the `release` job in
    `.github/workflows/ci.yml`, which:
 
    1. Reads the `version` value from `Cargo.toml`.


### PR DESCRIPTION
Closes #117

## Summary

- New `Semver Checks` job in `.github/workflows/ci.yml`, sitting between `Documentation` and `no-std`. Runs `cargo semver-checks check-release --verbose` to diff the candidate's public API against the last crates.io release.
- `CI Success` aggregate is updated: `semver_checks` added to `needs`, to the printed status table, and to the gating expression. Failing semver checks blocks merge.
- `RELEASE.md` step 6 documents the new gate and corrects step 7 (`rebase-merge` → `squash-merge` to match `docs/BRANCHING.md` from #116).

## Why a gate, not advisory

Past KaiCode winner novops drew jury praise for continuous deployment; one half of "deployment discipline" is reliably-truthful version numbers. Without a gate, a renamed `pub fn` shipped under a patch bump is a one-line code review miss and a permanent semver lie in the consumer's `Cargo.toml`. The gate makes that impossible.

## Local verification

- `cargo semver-checks check-release --verbose` — `196 pass, 56 skip`, `Summary no semver update required`
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green on both commits

## Test plan

- [ ] `Semver Checks` job runs and stays green against the unchanged public API
- [ ] `CI Success` aggregate green