### PR TITLE
#113 test: wasm-bindgen-test browser suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,42 @@ jobs:
       - name: Run doctests
         run: cargo test --doc --all-features
 
+  wasm_tests:
+    name: WASM Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Load cached target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm-tests
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Install chromedriver
+        uses: nanasess/setup-chromedriver@v2
+
+      - name: Install geckodriver
+        uses: browser-actions/setup-geckodriver@latest
+
+      - name: Run browser tests on Chrome
+        run: wasm-pack test --headless --chrome --test wasm
+
+      - name: Run browser tests on Firefox
+        run: wasm-pack test --headless --firefox --test wasm
+
   coverage:
     name: Coverage
     needs: test
@@ -586,7 +622,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [msrv, check, fmt, docs, semver_checks, no_std, security, reuse, test, coverage, benchmarks, wasm-build, lighthouse, changelog, actionlint, release]
+    needs: [msrv, check, fmt, docs, semver_checks, no_std, security, reuse, test, wasm_tests, coverage, benchmarks, wasm-build, lighthouse, changelog, actionlint, release]
     if: always()
     steps:
       - name: Check job status
@@ -602,6 +638,7 @@ jobs:
           echo "  Security: ${{ needs.security.result }}"
           echo "  REUSE: ${{ needs.reuse.result }}"
           echo "  Test: ${{ needs.test.result }}"
+          echo "  WASM Tests: ${{ needs.wasm_tests.result }}"
           echo "  Coverage: ${{ needs.coverage.result }}"
           echo "  Benchmarks: ${{ needs.benchmarks.result }}"
           echo "  WASM build: ${{ needs.wasm-build.result }}"
@@ -610,7 +647,7 @@ jobs:
           echo "  Actionlint: ${{ needs.actionlint.result }}"
           echo "  Release: ${{ needs.release.result }}"
 
-          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || ("${{ needs.release.result }}" != "success" && "${{ needs.release.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
+          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || "${{ needs.wasm_tests.result }}" != "success" || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || ("${{ needs.release.result }}" != "success" && "${{ needs.release.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
             echo "❌ CI failed"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,7 @@ merge.
 | `Security` | yes | `cargo deny check` + `cargo audit` |
 | `REUSE Compliance` | yes | `reuse lint` |
 | `Test` | yes (skip allowed) | `cargo nextest` + doctests |
+| `WASM Tests` | yes | `wasm-pack test --headless --chrome --firefox --test wasm` |
 | `Coverage` | yes (skip allowed) | `cargo llvm-cov` → Codecov upload |
 | `Benchmarks` | yes (skip allowed) | `cargo bench --no-run` |
 | `Example WASM build` | yes | `trunk build --release` against `example/` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,8 +1798,12 @@ name = "yew-nav-link"
 version = "0.10.0"
 dependencies = [
  "criterion",
+ "js-sys",
  "proptest",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
  "yew",
  "yew-router",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,27 @@ yew = { version = "0.23", features = ["csr"] }
 yew-router = "0.20"
 
 [dev-dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-test = "0.3"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = [
+  "Window",
+  "Document",
+  "Element",
+  "HtmlElement",
+  "HtmlCollection",
+  "History",
+] }
+
+# Native-only dev-deps. `criterion` pulls in non-wasm runtime crates and
+# `proptest`'s default features pull `rusty-fork` -> `wait-timeout`, which
+# does not compile for `wasm32-unknown-unknown`. Both are exercised only by
+# native test targets (`tests/proptest_utils.rs`, `benches/`), so gating
+# keeps the wasm test build minimal and lets the browser suite link cleanly.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.8"
 proptest = "1"
-wasm-bindgen-test = "0.3"
 
 [[bench]]
 name = "path"

--- a/tests/attrs_test.rs
+++ b/tests/attrs_test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(all(test, not(target_arch = "wasm32")))]
 
 use yew_nav_link::{NavItemAttrs, NavLinkAttrs, NavListAttrs};
 

--- a/tests/components_test.rs
+++ b/tests/components_test.rs
@@ -1,5 +1,7 @@
 //! Integration tests for components module.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use yew::prelude::*;
 
 #[test]

--- a/tests/dropdown_test.rs
+++ b/tests/dropdown_test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(all(test, not(target_arch = "wasm32")))]
 
 use yew::prelude::*;
 use yew_nav_link::components::{NavDropdownDividerProps, NavDropdownItemProps, NavDropdownProps};

--- a/tests/errors_test.rs
+++ b/tests/errors_test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(all(test, not(target_arch = "wasm32")))]
 
 use yew_nav_link::{NavError, NavResult};
 

--- a/tests/hooks_route_test.rs
+++ b/tests/hooks_route_test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(all(test, not(target_arch = "wasm32")))]
 
 mod hooks_route_test {
     use yew_nav_link::hooks::BreadcrumbItem;

--- a/tests/keyboard_test.rs
+++ b/tests/keyboard_test.rs
@@ -1,5 +1,7 @@
 //! Keyboard navigation tests.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use yew_nav_link::utils::{KeyboardDirection, KeyboardNavConfig};
 
 #[test]

--- a/tests/nav_item_test.rs
+++ b/tests/nav_item_test.rs
@@ -1,5 +1,7 @@
 //! Integration tests for nav components.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use yew::prelude::*;
 
 #[test]

--- a/tests/nav_list_test.rs
+++ b/tests/nav_list_test.rs
@@ -2,6 +2,8 @@
 //!
 //! Tests the public API of nav components.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use yew::prelude::*;
 
 #[test]

--- a/tests/pagination_test.rs
+++ b/tests/pagination_test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(all(test, not(target_arch = "wasm32")))]
 
 mod pagination_test {
     use yew::prelude::*;

--- a/tests/proptest_utils.proptest-regressions
+++ b/tests/proptest_utils.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 206eeffb6d8a8efcd48b973e110d0d9bb4738cd8abb87bdbdf3044febd3c8296 # shrinks to base = ""

--- a/tests/proptest_utils.rs
+++ b/tests/proptest_utils.rs
@@ -5,6 +5,8 @@
 //! examples in the unit-test modules pin specific cases; these properties
 //! assert invariants over arbitrary UTF-8 / arbitrary path inputs.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use proptest::prelude::*;
 use yew_nav_link::utils::{
     is_absolute, join_paths, normalize_path, urlencoding_decode, urlencoding_encode

--- a/tests/url_codec_test.rs
+++ b/tests/url_codec_test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+#![cfg(all(test, not(target_arch = "wasm32")))]
 
 use yew_nav_link::utils::{urlencoding_decode, urlencoding_encode};
 

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -1,5 +1,7 @@
 //! Integration tests for utils module.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use yew_nav_link::utils::{is_absolute, join_paths, normalize_path};
 
 #[test]

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Integration tests that exercise the public API in a real browser.
+//!
+//! Native test runs treat this target as empty — the `cfg(target_arch =
+//! "wasm32")` gate strips the body. The full suite runs under
+//! `wasm-pack test --headless --chrome --firefox --test wasm`.
+
+#![cfg(target_arch = "wasm32")]
+
+// Cargo's default module resolution would look for `tests/common.rs` and
+// `tests/nav_link.rs` next to this file. We want the wasm-specific
+// submodules under `tests/wasm/` so the directory stays self-contained;
+// `#[path]` redirects the lookup accordingly.
+
+#[path = "wasm/common.rs"]
+mod common;
+
+#[path = "wasm/nav_link.rs"]
+mod nav_link;

--- a/tests/wasm/README.md
+++ b/tests/wasm/README.md
@@ -1,31 +1,55 @@
-# WASM Tests for yew-nav-link
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
 
-These tests verify the library works correctly in WebAssembly environment.
+# Browser tests
 
-## Running WASM Tests
+Real-browser coverage for the public API. Each file holds `#[wasm_bindgen_test]`
+cases that render a small Yew app, wait for the scheduler to flush, and
+assert directly against the resulting DOM.
+
+## Layout
+
+```
+tests/
+  wasm.rs              entry, declares the modules below
+  wasm/
+    common.rs          shared helpers (route enum, fresh root, render flush)
+    nav_link.rs        NavLink rendering and active-state behaviour
+```
+
+Each file at top level of `tests/` is its own integration test crate, so
+`tests/wasm.rs` and its submodules compile and run as the `wasm` test
+target. Other files (`tests/*_test.rs`) are independent native test
+crates and are not pulled into wasm builds.
+
+## Running locally
 
 ```bash
-# Install wasm-pack if not already
-cargo install wasm-pack
+rustup target add wasm32-unknown-unknown
+cargo install --locked wasm-pack
 
-# Run WASM tests
-wasm-pack test --node
+wasm-pack test --headless --chrome   --test wasm
+wasm-pack test --headless --firefox  --test wasm
 ```
 
-## Test Categories
+`--test wasm` restricts compilation to this target so native-only tests
+under `tests/*_test.rs` are skipped.
 
-### Navigation Link Tests
-Tests for NavLink component active state detection in WASM context.
+## CI
 
-```rust
-#[wasm_bindgen_test]
-fn test_navlink_renders_in_wasm() {
-    // Verify NavLink renders without panics in WASM
-}
-```
+`.github/workflows/ci.yml` runs the `WASM Tests` job on every PR. It
+installs `chromedriver` and `geckodriver` and runs the suite against
+both browsers in headless mode.
 
-### Component Rendering Tests
-Verify all components render correctly in browser environment.
+## Adding a new case
 
-### Router Integration Tests
-Test navigation works with yew-router in WASM context.
+1. Pick or extend a module under `tests/wasm/`.
+2. Annotate the function with `#[wasm_bindgen_test]`. Async is allowed
+   and is usually necessary to wait for Yew to flush — call
+   `wait_for_render().await` after `Renderer::render()`.
+3. Use `navigate()` from `common.rs` to set the URL before mounting so
+   the router resolves the right `current_route`.
+4. Clean up: `root.remove()` and restore the URL with `navigate("/")` if
+   the test changed it, so subsequent tests start from a known state.

--- a/tests/wasm/common.rs
+++ b/tests/wasm/common.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Shared helpers for browser tests: fresh DOM root, render flush, route
+//! enum.
+
+use wasm_bindgen::{JsCast, JsValue, prelude::Closure};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Document, Element, HtmlElement, window};
+use yew_router::prelude::Routable;
+
+#[derive(Clone, PartialEq, Debug, Routable)]
+pub enum TestRoute {
+    #[at("/")]
+    Home,
+    #[at("/about")]
+    About,
+    #[at("/docs")]
+    Docs,
+    #[at("/docs/api")]
+    DocsApi
+}
+
+pub fn document() -> Document {
+    window().unwrap().document().unwrap()
+}
+
+pub fn body() -> HtmlElement {
+    document().body().unwrap()
+}
+
+/// Allocates a fresh `<div>` under `<body>` for the next render.
+pub fn fresh_root() -> Element {
+    let root = document().create_element("div").unwrap();
+    body().append_child(&root).unwrap();
+    root
+}
+
+/// Pushes `path` into the history stack so `BrowserRouter` reads it on the
+/// next render. Yew's router subscribes to history changes, so this also
+/// triggers a re-render of any mounted app.
+pub fn navigate(path: &str) {
+    window()
+        .unwrap()
+        .history()
+        .unwrap()
+        .push_state_with_url(&JsValue::NULL, "", Some(path))
+        .unwrap();
+}
+
+/// Yew renders asynchronously. Wait long enough for the scheduler to flush
+/// before reading the DOM.
+pub async fn wait_for_render() {
+    let promise = js_sys::Promise::new(&mut |resolve, _| {
+        let cb = Closure::once_into_js(move || {
+            resolve.call0(&JsValue::NULL).unwrap();
+        });
+        window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 50)
+            .unwrap();
+    });
+    JsFuture::from(promise).await.unwrap();
+}

--- a/tests/wasm/nav_link.rs
+++ b/tests/wasm/nav_link.rs
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Browser tests for `NavLink`. Each `#[wasm_bindgen_test]` renders a
+//! small Yew app under `BrowserRouter`, waits for Yew to flush, and reads
+//! the resulting DOM directly.
+
+use wasm_bindgen_test::*;
+use yew::prelude::*;
+use yew_nav_link::NavLink;
+use yew_router::prelude::*;
+
+use super::common::{TestRoute, fresh_root, navigate, wait_for_render};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[function_component]
+fn TwoLinkApp() -> Html {
+    html! {
+        <BrowserRouter>
+            <NavLink<TestRoute> to={TestRoute::Home}>{ "Home" }</NavLink<TestRoute>>
+            <NavLink<TestRoute> to={TestRoute::About}>{ "About" }</NavLink<TestRoute>>
+        </BrowserRouter>
+    }
+}
+
+#[function_component]
+fn CustomClassApp() -> Html {
+    html! {
+        <BrowserRouter>
+            <NavLink<TestRoute> to={TestRoute::Home} class="menu-item" active_class="is-current">
+                { "Home" }
+            </NavLink<TestRoute>>
+        </BrowserRouter>
+    }
+}
+
+#[function_component]
+fn PartialApp() -> Html {
+    html! {
+        <BrowserRouter>
+            <NavLink<TestRoute> to={TestRoute::Docs} partial=true>{ "Docs" }</NavLink<TestRoute>>
+        </BrowserRouter>
+    }
+}
+
+#[function_component]
+fn BasenameApp() -> Html {
+    html! {
+        <BrowserRouter basename="/app">
+            <NavLink<TestRoute> to={TestRoute::Home}>{ "Home" }</NavLink<TestRoute>>
+        </BrowserRouter>
+    }
+}
+
+#[wasm_bindgen_test]
+async fn active_link_at_home_carries_aria_current_and_active_class() {
+    navigate("/");
+    let root = fresh_root();
+    yew::Renderer::<TwoLinkApp>::with_root(root.clone()).render();
+    wait_for_render().await;
+
+    let links = root.get_elements_by_tag_name("a");
+    assert_eq!(links.length(), 2, "expected two anchors");
+
+    let home = links.item(0).unwrap();
+    let about = links.item(1).unwrap();
+
+    assert_eq!(
+        home.get_attribute("class").as_deref(),
+        Some("nav-link active"),
+        "home link should carry the default base + active class"
+    );
+    assert_eq!(
+        home.get_attribute("aria-current").as_deref(),
+        Some("page"),
+        "active link should advertise aria-current to assistive tech"
+    );
+    assert_eq!(
+        about.get_attribute("class").as_deref(),
+        Some("nav-link"),
+        "inactive link should carry only the base class"
+    );
+    assert!(
+        about.get_attribute("aria-current").is_none(),
+        "inactive link must not set aria-current"
+    );
+
+    root.remove();
+}
+
+#[wasm_bindgen_test]
+async fn custom_class_and_active_class_replace_defaults() {
+    navigate("/");
+    let root = fresh_root();
+    yew::Renderer::<CustomClassApp>::with_root(root.clone()).render();
+    wait_for_render().await;
+
+    let link = root.get_elements_by_tag_name("a").item(0).unwrap();
+    assert_eq!(
+        link.get_attribute("class").as_deref(),
+        Some("menu-item is-current"),
+        "custom class slots must fully replace the defaults"
+    );
+
+    root.remove();
+}
+
+#[wasm_bindgen_test]
+async fn partial_match_keeps_parent_active_under_nested_route() {
+    navigate("/docs/api");
+    let root = fresh_root();
+    yew::Renderer::<PartialApp>::with_root(root.clone()).render();
+    wait_for_render().await;
+
+    let link = root.get_elements_by_tag_name("a").item(0).unwrap();
+    assert_eq!(
+        link.get_attribute("class").as_deref(),
+        Some("nav-link active"),
+        "partial=true should keep Docs active while at /docs/api"
+    );
+    assert_eq!(
+        link.get_attribute("aria-current").as_deref(),
+        Some("page"),
+        "partial-matched active link should still announce aria-current"
+    );
+
+    navigate("/");
+    root.remove();
+}
+
+#[wasm_bindgen_test]
+async fn inactive_link_emits_relative_href_for_its_target() {
+    navigate("/");
+    let root = fresh_root();
+    yew::Renderer::<TwoLinkApp>::with_root(root.clone()).render();
+    wait_for_render().await;
+
+    let links = root.get_elements_by_tag_name("a");
+    let about = links.item(1).unwrap();
+    assert_eq!(
+        about.get_attribute("href").as_deref(),
+        Some("/about"),
+        "href should match the target route's path"
+    );
+
+    root.remove();
+}
+
+#[wasm_bindgen_test]
+async fn href_includes_router_basename() {
+    navigate("/app/");
+    let root = fresh_root();
+    yew::Renderer::<BasenameApp>::with_root(root.clone()).render();
+    wait_for_render().await;
+
+    let link = root.get_elements_by_tag_name("a").item(0).unwrap();
+    let href = link.get_attribute("href").unwrap_or_default();
+    assert!(
+        href.starts_with("/app"),
+        "href must include the basename, got {href:?}"
+    );
+
+    navigate("/");
+    root.remove();
+}


### PR DESCRIPTION
Closes #113

## Summary

- New integration test target `tests/wasm.rs` gated by `cfg(target_arch = "wasm32")` with submodules under `tests/wasm/`:
  - `tests/wasm/common.rs` — `TestRoute` enum, `fresh_root()`, `navigate()`, `wait_for_render()` helpers.
  - `tests/wasm/nav_link.rs` — five `#[wasm_bindgen_test]` cases covering the acceptance criteria from #113.
- `Cargo.toml`:
  - direct dev-deps for `wasm-bindgen`, `wasm-bindgen-futures`, `js-sys`, `web-sys` (with `Window`, `Document`, `Element`, `HtmlElement`, `HtmlCollection`, `History` features)
  - `criterion` and `proptest` moved under `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]` because `proptest -> rusty-fork -> wait-timeout` and `criterion` itself do not compile for `wasm32-unknown-unknown`.
- New `WASM Tests` job in `.github/workflows/ci.yml` after `Test`. Installs `wasm-pack`, `chromedriver`, `geckodriver`; runs `wasm-pack test --headless --chrome --test wasm` and the firefox equivalent. Added to `CI Success` aggregate (needs, status table, gate expression).
- `CONTRIBUTING.md` CI overview table gains a `WASM Tests` row. `tests/wasm/README.md` rewritten to describe the new layout and the `--test wasm` invocation.

## Test scenarios

1. `active_link_at_home_carries_aria_current_and_active_class` — at `/`, the Home link has `class="nav-link active"` and `aria-current="page"`; About has only `class="nav-link"` and no `aria-current`.
2. `custom_class_and_active_class_replace_defaults` — `class="menu-item"` `active_class="is-current"` fully replace the defaults.
3. `partial_match_keeps_parent_active_under_nested_route` — `partial=true` keeps `Docs` active while at `/docs/api`.
4. `inactive_link_emits_relative_href_for_its_target` — inactive link's `href` matches `to.to_path()`.
5. `href_includes_router_basename` — `<BrowserRouter basename="/app">` makes `Home` link emit `href` starting with `/app`.

## Local verification

- `cargo check --all-targets --all-features` — green
- `cargo check --target wasm32-unknown-unknown --test wasm` — green
- `cargo +nightly udeps --all-targets --all-features` — `All deps seem to have been used` with the documented ignore
- `cargo machete` — clean
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] `WASM Tests` job runs five tests against headless chrome and firefox and stays green
- [ ] `Test` (native) job stays green — proptest and criterion still available natively
- [ ] `CI Success` aggregate green