### PR TITLE
#118 ci: automate releases with release-plz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,97 +594,10 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  release:
-    name: Release
-    needs: [msrv, check, fmt, docs, no_std, security, reuse, changelog, actionlint]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-
-      - name: Load cached target directory
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: release
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Check version change
-        id: version_check
-        run: |
-          CURRENT_VERSION=$(grep -E "version\s*=\s*\"" Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          LATEST_VERSION=${LATEST_TAG#v}
-          
-          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "latest_version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-          
-          if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
-            echo "version_changed=true" >> "$GITHUB_OUTPUT"
-            echo "Version has changed from $LATEST_VERSION to $CURRENT_VERSION"
-          else
-            echo "version_changed=false" >> "$GITHUB_OUTPUT"
-            echo "Version unchanged"
-          fi
-
-      - name: Build release artifact
-        run: cargo build --release --all-features
-
-      - name: Publish to crates.io
-        if: steps.version_check.outputs.version_changed == 'true'
-        run: |
-          cargo login ${{ secrets.CRATES_IO_TOKEN }}
-          cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-
-      - name: Extract release notes from CHANGELOG.md
-        id: notes
-        if: steps.version_check.outputs.version_changed == 'true'
-        env:
-          VERSION: ${{ steps.version_check.outputs.current_version }}
-        run: |
-          # Pull the section between "## [VERSION] - …" (exclusive) and the
-          # next "## [" header (exclusive). Falls back to a generic line if
-          # the entry is missing so the release is still populated.
-          notes_file="$(mktemp)"
-          awk -v v="$VERSION" '
-            BEGIN { in_section = 0 }
-            /^## \[/ {
-              if (in_section) { exit }
-              if ($0 ~ "^## \\[" v "\\]") { in_section = 1; next }
-            }
-            in_section { print }
-          ' CHANGELOG.md > "$notes_file"
-
-          if [ ! -s "$notes_file" ]; then
-            echo "Release v$VERSION." > "$notes_file"
-          fi
-
-          echo "path=$notes_file" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub release
-        if: steps.version_check.outputs.version_changed == 'true'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: v${{ steps.version_check.outputs.current_version }}
-          name: v${{ steps.version_check.outputs.current_version }}
-          body_path: ${{ steps.notes.outputs.path }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [msrv, check, fmt, docs, semver_checks, no_std, security, reuse, test, wasm_tests, coverage, benchmarks, wasm-build, e2e, lighthouse, changelog, actionlint, release]
+    needs: [msrv, check, fmt, docs, semver_checks, no_std, security, reuse, test, wasm_tests, coverage, benchmarks, wasm-build, e2e, lighthouse, changelog, actionlint]
     if: always()
     steps:
       - name: Check job status
@@ -708,9 +621,8 @@ jobs:
           echo "  Lighthouse: ${{ needs.lighthouse.result }}"
           echo "  Changelog: ${{ needs.changelog.result }}"
           echo "  Actionlint: ${{ needs.actionlint.result }}"
-          echo "  Release: ${{ needs.release.result }}"
 
-          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || "${{ needs.wasm_tests.result }}" != "success" || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.e2e.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || ("${{ needs.release.result }}" != "success" && "${{ needs.release.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
+          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || "${{ needs.wasm_tests.result }}" != "success" || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.e2e.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
             echo "❌ CI failed"
             exit 1
           fi

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Two-mode release automation driven by release-plz:
+#   `release-pr` keeps a single release PR open against `main`, bumping
+#   the version and prepending a CHANGELOG section as conventional
+#   commits land;
+#   `release` runs after the release PR is merged — it tags the commit,
+#   publishes to crates.io, and creates the matching GitHub release.
+#
+# See `release-plz.toml` for the per-package configuration and
+# `RELEASE.md` for the human-facing flow.
+
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'RAprogramm' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'RAprogramm' }}
+    needs: release-plz-release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz release-pr
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,10 +153,14 @@ merge.
 | `Lighthouse` | yes | thresholds: perf 0.85, a11y 0.9, best-practices 0.9, SEO 0.9 |
 | `Actionlint` | yes | lints all workflow YAML |
 | `Changelog` | yes (skip allowed) | runs `git-cliff` |
-| `Release` | yes (skip allowed) | publishes on push to `main` when `Cargo.toml` version changes |
 
-A separate `.github/workflows/pages.yml` deploys the demo to
-<https://raprogramm.github.io/yew-nav-link/> on push to `main`.
+Two more workflows handle deployment side-effects on push to `main`:
+
+- `.github/workflows/pages.yml` deploys the demo to
+  <https://raprogramm.github.io/yew-nav-link/>.
+- `.github/workflows/release-plz.yml` opens / updates the release PR
+  and, when that PR is merged, tags + publishes to crates.io + creates
+  the GitHub release. See [`RELEASE.md`](RELEASE.md) for the full flow.
 
 ## Releasing
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,11 +5,16 @@ SPDX-License-Identifier: MIT
 
 # Release process
 
-`yew-nav-link` releases are driven by the version field in `Cargo.toml`.
-Push a commit to `main` whose `Cargo.toml` carries a higher version than
-the latest git tag, and CI does the rest: it publishes to crates.io,
-tags the commit, and creates a GitHub release whose body comes from the
-matching `CHANGELOG.md` section.
+`yew-nav-link` releases are driven by [release-plz][rplz]. Conventional
+commits land on `main`; release-plz reads them, opens a "release PR"
+that bumps `Cargo.toml` and prepends a section to `CHANGELOG.md`, and
+when that PR is squash-merged it tags the commit, publishes to
+crates.io, and creates the GitHub release.
+
+There is no manual version-bump path. The maintainer's only release
+action is to review and merge the release PR.
+
+[rplz]: https://release-plz.dev
 
 ## Versioning policy
 
@@ -19,74 +24,112 @@ Cargo's `0.x` interpretation:
 
 - While the major is `0`, **breaking changes** bump the minor
   (`0.x → 0.(x+1)`).
-- **Additive, non-breaking** changes (new public exports, bug fixes) bump
-  the patch (`0.x.y → 0.x.(y+1)`).
+- **Additive, non-breaking** changes (new public exports, bug fixes)
+  bump the patch (`0.x.y → 0.x.(y+1)`).
 
 After 1.0 the standard major/minor/patch rules apply.
 
-## Cutting a release
+`Semver Checks` (`cargo semver-checks`) runs on every PR and blocks a
+release whose API change exceeds the version bump. release-plz reads
+the same conventional commits to decide the bump, so by the time a
+release PR exists the version and the diff already agree.
 
-1. **Decide the new version.** Look at the merged work since the last
-   tag. Anything in `[Unreleased]` of `CHANGELOG.md` that changes the
-   public API forces a minor bump in the 0.x line.
+## How a release happens
 
-2. **Open an issue** named `Release vX.Y.Z` (per the standard
-   `CONTRIBUTING.md` workflow). Branch named after the issue.
+```
+conventional commit on main
+        │
+        ▼
+release-plz-pr job (workflow: Release-plz)
+        │
+        ▼
+release PR — open or updated, with Cargo.toml + CHANGELOG diff
+        │
+        ▼  (maintainer reviews, CI runs, semver gate passes)
+        │
+        ▼
+squash-merge to main
+        │
+        ▼
+release-plz-release job
+        │
+        ├─► git tag vX.Y.Z (annotated)
+        ├─► cargo publish
+        └─► gh release create with body from the CHANGELOG section
+```
 
-3. **Edit `Cargo.toml`** — set `version = "X.Y.Z"`.
+The trigger is `push` to `main`; both jobs live in
+`.github/workflows/release-plz.yml`. The `release-pr` job keeps the
+release PR fresh after each commit; the `release` job runs after the
+release PR's merge commit lands.
 
-4. **Update `CHANGELOG.md`.** Replace the `## [Unreleased]` heading with
-   `## [Unreleased]` followed by `## [X.Y.Z] - YYYY-MM-DD` and move the
-   relevant entries underneath. Group entries under the standard
-   `Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`
-   headings (see [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)).
+## Configuration
 
-5. **Refresh `Cargo.lock`** by running any cargo command (`cargo check`).
-   Commit the lock-file update separately to keep the diff readable:
+- `release-plz.toml` — per-package settings: `git_tag_name = "v{{ version }}"`, `git_release_name = "v{{ version }}"`, changelog mapping that mirrors `cliff.toml` (`feat` → Features, `fix` → Bug Fixes, …).
+- `.github/workflows/release-plz.yml` — the two jobs. Concurrency is keyed on `release-plz-${{ github.ref }}` so two pushes never race a release PR update.
 
-   ```
-   #N feat: <feature>
-   #N chore: refresh Cargo.lock for X.Y.Z version bump
-   ```
+The `CRATES_IO_TOKEN` repository secret is reused from the previous
+manual flow. `GITHUB_TOKEN` is the standard workflow token with
+`contents: write` + `pull-requests: write` granted in the workflow.
 
-6. **Open a PR**, wait for `CI Success` to pass.
+## What the maintainer still does
 
-   The `Semver Checks` job runs `cargo semver-checks check-release`
-   against the previously-published crates.io version. If your changes
-   touch the public API in a way that does not match the version bump
-   in step 3, this job fails — re-decide the version (a wider bump or
-   smaller change) and make the PR consistent. Update both directions
-   here, never bypass the gate with `--allow-...` flags.
+1. **Land conventional commits on `main`.** Prefix decides changelog
+   group and version bump:
 
-7. **Squash-merge to `main`.** That push triggers the `release` job in
-   `.github/workflows/ci.yml`, which:
+   | Prefix | Section | Bump |
+   |---|---|---|
+   | `feat` | Features | minor (or major with `feat!`) |
+   | `fix` | Bug Fixes | patch |
+   | `docs` | Documentation | patch |
+   | `refactor` | Refactoring | patch |
+   | `ci` | CI | patch |
+   | `deps`, `chore(deps)` | Dependencies | patch |
+   | `test`, `chore` | (skipped) | none |
 
-   1. Reads the `version` value from `Cargo.toml`.
-   2. Compares against the latest tag (`git describe --tags --abbrev=0`).
-   3. Runs `cargo build --release --all-features` as a final smoke test.
-   4. Publishes via `cargo publish` using `CRATES_IO_TOKEN`.
-   5. Extracts the matching `[X.Y.Z]` section from `CHANGELOG.md` via
-      `awk` into a temp file (see the **Extract release notes** step).
-   6. Calls `softprops/action-gh-release@v2` with the temp file as
-      `body_path` and `generate_release_notes: true` so GitHub appends
-      the auto-generated PR list under our handwritten changelog.
-   7. Tags the commit `vX.Y.Z`.
+2. **Wait for the release PR.** It appears within a minute of the
+   triggering push (release-plz reuses the same PR across pushes).
 
-8. **Verify.** Within a minute:
+3. **Review and merge it.** Squash-merge, deletion of the release-plz
+   branch is automatic.
 
+4. **Verify.** Within a minute of the merge:
    - <https://crates.io/crates/yew-nav-link> shows the new version.
-   - <https://docs.rs/yew-nav-link> rebuilds (may take a few extra
-     minutes).
-   - <https://github.com/RAprogramm/yew-nav-link/releases/tag/vX.Y.Z>
-     exists with a populated body.
+   - <https://docs.rs/yew-nav-link> rebuilds (a few extra minutes).
+   - <https://github.com/RAprogramm/yew-nav-link/releases> has a
+     populated entry whose body is the CHANGELOG section for the
+     version.
 
-   If any of these is missing, check the `release` job in the
-   most-recent `CI` workflow run on `main`.
+   If any of these is missing, inspect the most recent run of the
+   `Release-plz` workflow on `main`.
+
+## Yanking
+
+If a release ships a regression severe enough that consumers should
+**not** pin it, yank it on crates.io:
+
+```bash
+cargo yank --version X.Y.Z
+```
+
+Document the reason in `CHANGELOG.md` under `### Security` or `### Fixed`
+of the next release. release-plz will pick the entry up on the next
+push.
+
+## Pre-release / RC versions
+
+The 0.9.x and 0.10.x series do not currently use pre-release tags.
+When 1.0 approaches, candidate cuts will use the standard
+`1.0.0-rc.N` form, which Cargo resolves correctly under
+`cargo install --version "<1.0"` semantics. release-plz supports
+pre-releases via `version_groups` in `release-plz.toml`; the config
+will gain that block at the 1.0 cut.
 
 ## Backfilling release notes
 
 Releases produced before PR #51 had empty bodies because the workflow
-used the deprecated `actions/create-release@v1`. To repopulate one:
+used the deprecated `actions/create-release@v1`. release-plz only
+manages future releases — to repopulate an older one:
 
 ```bash
 notes=$(mktemp)
@@ -101,22 +144,3 @@ awk -v v="0.9.2" '
 gh release edit "v0.9.2" --notes-file "$notes"
 rm "$notes"
 ```
-
-## Yanking
-
-If a release ships a regression severe enough that consumers should
-**not** pin it, yank the version on crates.io:
-
-```bash
-cargo yank --version X.Y.Z
-```
-
-Document the reason in `CHANGELOG.md` under `### Security` or `### Fixed`
-of the next release.
-
-## Pre-release / RC versions
-
-The 0.9.x and 0.10.x series do not currently use pre-release tags.
-When 1.0 approaches, candidate cuts will use the standard
-`1.0.0-rc.N` form, which Cargo resolves correctly under
-`cargo install --version "<1.0"` semantics.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# release-plz drives the release cadence for `yew-nav-link`:
+#   1. on every push to `main`, it computes the next version from
+#      conventional commits since the latest tag and opens (or updates)
+#      a release PR that bumps `Cargo.toml` and prepends a section to
+#      `CHANGELOG.md`;
+#   2. when that release PR is squash-merged, it publishes to crates.io,
+#      tags `vX.Y.Z`, and creates the GitHub release.
+#
+# Reference: https://release-plz.dev
+
+[workspace]
+allow_dirty = false
+changelog_update = true
+git_release_enable = true
+git_tag_enable = true
+publish = true
+publish_allow_dirty = false
+release = true
+
+[[package]]
+name = "yew-nav-link"
+# Mirror the section structure of the existing CHANGELOG so the diff
+# stays minimal when release-plz writes a new release entry.
+changelog_path = "CHANGELOG.md"
+git_release_name = "v{{ version }}"
+git_tag_name = "v{{ version }}"
+publish_features = ["default"]
+
+[changelog]
+# Map conventional commits to the same headings cliff.toml has been using
+# so the merged CHANGELOG remains stylistically consistent.
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^ci", group = "CI" },
+    { message = "^deps|^chore\\(deps\\)", group = "Dependencies" },
+    { message = "^chore", skip = true },
+    { message = "^test", skip = true },
+]
+sort_commits = "newest"
+trim = true


### PR DESCRIPTION
Closes #118

## Summary

- `release-plz.toml` — per-package config: tag template `v{{ version }}`, release name `v{{ version }}`, publish to crates.io, changelog mapping that mirrors `cliff.toml` so the merged CHANGELOG stays stylistically consistent.
- `.github/workflows/release-plz.yml` — two jobs on `push: main`:
  - `release-plz-release` runs after the release PR is merged: tags, publishes, creates the GitHub release.
  - `release-plz-pr` keeps a single release PR open against `main`, bumping the version and prepending a CHANGELOG section as conventional commits land.
- `.github/workflows/ci.yml`: the manual `release:` job (lines 597–682 on `main`) is gone. `CI Success` aggregate is updated — `release` dropped from `needs`, from the printed status table, and from the gate expression.
- `RELEASE.md` rewritten end-to-end: now describes the release-plz flow (PR open/update → review → squash-merge → publish), keeps the yank and pre-release sections, and documents the maintainer's one remaining action.
- `CONTRIBUTING.md` CI overview drops the `Release` row and gains a paragraph pointing at `release-plz.yml` and `pages.yml` as the two deploy-time workflows.

`CRATES_IO_TOKEN` secret is reused from the previous flow. `GITHUB_TOKEN` is granted `contents: write` and `pull-requests: write` only where needed.

## Why automate

KaiCode 2025 jury praised novops's `release-please` flow under "continuous deployment". `release-plz` is the Rust-native analogue and reads the same conventional commits `cliff.toml` already parses. It also fixes a latent footgun: under the manual flow, a forgotten Cargo.toml bump silently shipped no release. Now the bump and the changelog entry are by-product of merging a PR.

## Local verification

- `actionlint .github/workflows/release-plz.yml` — clean
- `actionlint .github/workflows/ci.yml` — clean
- `reuse lint` — 133/133 files SPDX-tagged
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] `CI Success` aggregate stays green after `release` removal
- [ ] First push to `main` after merge opens a Release-plz PR within a minute
- [ ] Workflow log shows `release-plz-release` skipping (no version bump on this PR's merge commit) and `release-plz-pr` doing the work