### PR TITLE
#124 ci: enforce public API surface via cargo-public-api baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Setup nightly Rust toolchain for rustdoc JSON
+        uses: dtolnay/rust-toolchain@nightly
+
       - name: Load cached target directory
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,59 @@ jobs:
       - name: Compare public API against the last crates.io release
         run: cargo semver-checks check-release --verbose
 
+  public_api:
+    name: Public API
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Load cached target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: public-api
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-public-api
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-public-api
+
+      - name: Verify public API matches docs/public-api.txt
+        run: |
+          set -euo pipefail
+          current=$(mktemp)
+          cargo public-api -sss > "$current"
+          if diff -u docs/public-api.txt "$current" > /tmp/papi.diff; then
+            echo "Public API surface matches the baseline."
+            exit 0
+          fi
+          {
+            echo "## Public API drift"
+            echo
+            echo "\`docs/public-api.txt\` no longer matches the surface that"
+            echo "\`cargo public-api -sss\` produces. Regenerate the baseline"
+            echo "with:"
+            echo
+            echo '```bash'
+            echo 'cargo public-api -sss > docs/public-api.txt'
+            echo '```'
+            echo
+            echo 'Diff:'
+            echo
+            echo '```diff'
+            cat /tmp/papi.diff
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Public API surface changed. Run 'cargo public-api -sss > docs/public-api.txt' and commit."
+          exit 1
+
   no_std:
     name: no-std
     runs-on: ubuntu-latest
@@ -597,7 +650,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [msrv, check, fmt, docs, semver_checks, no_std, security, reuse, test, wasm_tests, coverage, benchmarks, wasm-build, e2e, lighthouse, changelog, actionlint]
+    needs: [msrv, check, fmt, docs, semver_checks, public_api, no_std, security, reuse, test, wasm_tests, coverage, benchmarks, wasm-build, e2e, lighthouse, changelog, actionlint]
     if: always()
     steps:
       - name: Check job status
@@ -609,6 +662,7 @@ jobs:
           echo "  Format: ${{ needs.fmt.result }}"
           echo "  Docs: ${{ needs.docs.result }}"
           echo "  Semver Checks: ${{ needs.semver_checks.result }}"
+          echo "  Public API: ${{ needs.public_api.result }}"
           echo "  no-std: ${{ needs.no_std.result }}"
           echo "  Security: ${{ needs.security.result }}"
           echo "  REUSE: ${{ needs.reuse.result }}"
@@ -622,7 +676,7 @@ jobs:
           echo "  Changelog: ${{ needs.changelog.result }}"
           echo "  Actionlint: ${{ needs.actionlint.result }}"
 
-          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || "${{ needs.wasm_tests.result }}" != "success" || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.e2e.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
+          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.public_api.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || "${{ needs.wasm_tests.result }}" != "success" || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.e2e.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
             echo "❌ CI failed"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,7 @@ merge.
 | `Format` | yes | nightly `rustfmt --check` |
 | `Lint (clippy)` | yes | pedantic + nursery |
 | `Documentation` | yes | `cargo doc --all-features` with `RUSTDOCFLAGS=-D warnings` |
+| `Public API` | yes | `cargo public-api -sss` must match `docs/public-api.txt` |
 | `no-std` | yes | informational stub (Yew is std-only) |
 | `Security` | yes | `cargo deny check` + `cargo audit` |
 | `REUSE Compliance` | yes | `reuse lint` |

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -1,0 +1,699 @@
+pub mod yew_nav_link
+pub mod yew_nav_link::active_link
+pub mod yew_nav_link::active_link::mode
+pub enum yew_nav_link::active_link::mode::Match
+pub yew_nav_link::active_link::mode::Match::Exact
+pub yew_nav_link::active_link::mode::Match::Partial
+impl core::fmt::Display for yew_nav_link::active_link::mode::Match
+pub fn yew_nav_link::active_link::mode::Match::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub mod yew_nav_link::active_link::nav_link
+pub struct yew_nav_link::active_link::nav_link::NavLink<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>
+impl<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static> yew::functional::FunctionProvider for yew_nav_link::active_link::nav_link::NavLink<R>
+pub type yew_nav_link::active_link::nav_link::NavLink<R>::Properties = yew_nav_link::active_link::props::NavLinkProps<R>
+pub fn yew_nav_link::active_link::nav_link::NavLink<R>::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub fn yew_nav_link::active_link::nav_link::nav_link<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>(to: R, children: &str, match_mode: yew_nav_link::active_link::mode::Match) -> yew::html::Html
+pub mod yew_nav_link::active_link::props
+pub struct yew_nav_link::active_link::props::NavLinkProps<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>
+pub yew_nav_link::active_link::props::NavLinkProps::active_class: &'static str
+pub yew_nav_link::active_link::props::NavLinkProps::children: yew::html::component::children::Children
+pub yew_nav_link::active_link::props::NavLinkProps::class: &'static str
+pub yew_nav_link::active_link::props::NavLinkProps::partial: bool
+pub yew_nav_link::active_link::props::NavLinkProps::to: R
+impl<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static> yew::html::component::properties::Properties for yew_nav_link::active_link::props::NavLinkProps<R>
+pub type yew_nav_link::active_link::props::NavLinkProps<R>::Builder = NavLinkPropsBuilder<R>
+pub fn yew_nav_link::active_link::props::NavLinkProps<R>::builder() -> Self::Builder
+pub mod yew_nav_link::active_link::utils
+pub fn yew_nav_link::active_link::utils::build_class(is_active: bool, base_class: &str, active_class: &str) -> alloc::string::String
+pub fn yew_nav_link::active_link::utils::is_path_prefix(target: &str, current: &str) -> bool
+pub enum yew_nav_link::active_link::Match
+pub yew_nav_link::active_link::Match::Exact
+pub yew_nav_link::active_link::Match::Partial
+impl core::fmt::Display for yew_nav_link::active_link::mode::Match
+pub fn yew_nav_link::active_link::mode::Match::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct yew_nav_link::active_link::NavLink<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>
+impl<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static> yew::functional::FunctionProvider for yew_nav_link::active_link::nav_link::NavLink<R>
+pub type yew_nav_link::active_link::nav_link::NavLink<R>::Properties = yew_nav_link::active_link::props::NavLinkProps<R>
+pub fn yew_nav_link::active_link::nav_link::NavLink<R>::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::active_link::NavLinkProps<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>
+pub yew_nav_link::active_link::NavLinkProps::active_class: &'static str
+pub yew_nav_link::active_link::NavLinkProps::children: yew::html::component::children::Children
+pub yew_nav_link::active_link::NavLinkProps::class: &'static str
+pub yew_nav_link::active_link::NavLinkProps::partial: bool
+pub yew_nav_link::active_link::NavLinkProps::to: R
+impl<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static> yew::html::component::properties::Properties for yew_nav_link::active_link::props::NavLinkProps<R>
+pub type yew_nav_link::active_link::props::NavLinkProps<R>::Builder = NavLinkPropsBuilder<R>
+pub fn yew_nav_link::active_link::props::NavLinkProps<R>::builder() -> Self::Builder
+pub fn yew_nav_link::active_link::is_path_prefix(target: &str, current: &str) -> bool
+pub fn yew_nav_link::active_link::nav_link<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>(to: R, children: &str, match_mode: yew_nav_link::active_link::mode::Match) -> yew::html::Html
+pub mod yew_nav_link::attrs
+pub struct yew_nav_link::attrs::NavItemAttrs
+pub yew_nav_link::attrs::NavItemAttrs::class: yew::html::classes::Classes
+pub yew_nav_link::attrs::NavItemAttrs::disabled: bool
+pub yew_nav_link::attrs::NavItemAttrs::id: core::option::Option<&'static str>
+pub yew_nav_link::attrs::NavItemAttrs::role: core::option::Option<&'static str>
+impl yew_nav_link::attrs::NavItemAttrs
+pub const fn yew_nav_link::attrs::NavItemAttrs::disabled(self) -> Self
+pub fn yew_nav_link::attrs::NavItemAttrs::new() -> Self
+pub fn yew_nav_link::attrs::NavItemAttrs::with_class(self, class: impl core::convert::Into<yew::html::classes::Classes>) -> Self
+pub const fn yew_nav_link::attrs::NavItemAttrs::with_id(self, id: &'static str) -> Self
+pub const fn yew_nav_link::attrs::NavItemAttrs::with_role(self, value: &'static str) -> Self
+pub struct yew_nav_link::attrs::NavLinkAttrs
+pub yew_nav_link::attrs::NavLinkAttrs::aria_current: core::option::Option<&'static str>
+pub yew_nav_link::attrs::NavLinkAttrs::class: yew::html::classes::Classes
+pub yew_nav_link::attrs::NavLinkAttrs::data_toggle: core::option::Option<&'static str>
+pub yew_nav_link::attrs::NavLinkAttrs::id: core::option::Option<&'static str>
+pub yew_nav_link::attrs::NavLinkAttrs::role: core::option::Option<&'static str>
+impl yew_nav_link::attrs::NavLinkAttrs
+pub fn yew_nav_link::attrs::NavLinkAttrs::new() -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_aria_current(self, value: &'static str) -> Self
+pub fn yew_nav_link::attrs::NavLinkAttrs::with_class(self, class: impl core::convert::Into<yew::html::classes::Classes>) -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_data_toggle(self, value: &'static str) -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_id(self, id: &'static str) -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_role(self, value: &'static str) -> Self
+pub struct yew_nav_link::attrs::NavListAttrs
+pub yew_nav_link::attrs::NavListAttrs::aria_label: core::option::Option<&'static str>
+pub yew_nav_link::attrs::NavListAttrs::class: yew::html::classes::Classes
+pub yew_nav_link::attrs::NavListAttrs::id: core::option::Option<&'static str>
+impl yew_nav_link::attrs::NavListAttrs
+pub fn yew_nav_link::attrs::NavListAttrs::new() -> Self
+pub const fn yew_nav_link::attrs::NavListAttrs::with_aria_label(self, label: &'static str) -> Self
+pub fn yew_nav_link::attrs::NavListAttrs::with_class(self, class: impl core::convert::Into<yew::html::classes::Classes>) -> Self
+pub const fn yew_nav_link::attrs::NavListAttrs::with_id(self, id: &'static str) -> Self
+pub mod yew_nav_link::components
+pub enum yew_nav_link::components::NavIconSize
+pub yew_nav_link::components::NavIconSize::Large
+pub yew_nav_link::components::NavIconSize::Medium
+pub yew_nav_link::components::NavIconSize::Small
+pub struct yew_nav_link::components::NavBadge
+impl yew::functional::FunctionProvider for yew_nav_link::NavBadge
+pub type yew_nav_link::NavBadge::Properties = yew_nav_link::NavBadgeProps
+pub fn yew_nav_link::NavBadge::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavBadgeProps
+pub yew_nav_link::components::NavBadgeProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavBadgeProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavBadgeProps::pill: bool
+pub yew_nav_link::components::NavBadgeProps::variant: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavBadgeProps
+pub type yew_nav_link::NavBadgeProps::Builder = NavBadgePropsBuilder
+pub fn yew_nav_link::NavBadgeProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavDropdown
+impl yew::functional::FunctionProvider for yew_nav_link::NavDropdown
+pub type yew_nav_link::NavDropdown::Properties = yew_nav_link::NavDropdownProps
+pub fn yew_nav_link::NavDropdown::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavDropdownDivider
+impl yew::functional::FunctionProvider for yew_nav_link::NavDropdownDivider
+pub type yew_nav_link::NavDropdownDivider::Properties = yew_nav_link::components::NavDropdownDividerProps
+pub fn yew_nav_link::NavDropdownDivider::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavDropdownDividerProps
+pub yew_nav_link::components::NavDropdownDividerProps::classes: yew::html::classes::Classes
+impl yew::html::component::properties::Properties for yew_nav_link::components::NavDropdownDividerProps
+pub type yew_nav_link::components::NavDropdownDividerProps::Builder = NavDropdownDividerPropsBuilder
+pub fn yew_nav_link::components::NavDropdownDividerProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavDropdownItem
+impl yew::functional::FunctionProvider for yew_nav_link::NavDropdownItem
+pub type yew_nav_link::NavDropdownItem::Properties = yew_nav_link::components::NavDropdownItemProps
+pub fn yew_nav_link::NavDropdownItem::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavDropdownItemProps
+pub yew_nav_link::components::NavDropdownItemProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavDropdownItemProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavDropdownItemProps::disabled: bool
+impl yew::html::component::properties::Properties for yew_nav_link::components::NavDropdownItemProps
+pub type yew_nav_link::components::NavDropdownItemProps::Builder = NavDropdownItemPropsBuilder
+pub fn yew_nav_link::components::NavDropdownItemProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavDropdownProps
+pub yew_nav_link::components::NavDropdownProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavDropdownProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavDropdownProps::id: core::option::Option<&'static str>
+pub yew_nav_link::components::NavDropdownProps::toggle_text: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavDropdownProps
+pub type yew_nav_link::NavDropdownProps::Builder = NavDropdownPropsBuilder
+pub fn yew_nav_link::NavDropdownProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavHeader
+impl yew::functional::FunctionProvider for yew_nav_link::NavHeader
+pub type yew_nav_link::NavHeader::Properties = yew_nav_link::NavHeaderProps
+pub fn yew_nav_link::NavHeader::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavHeaderProps
+pub yew_nav_link::components::NavHeaderProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavHeaderProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavHeaderProps::text: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavHeaderProps
+pub type yew_nav_link::NavHeaderProps::Builder = NavHeaderPropsBuilder
+pub fn yew_nav_link::NavHeaderProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavIcon
+impl yew::functional::FunctionProvider for yew_nav_link::NavIcon
+pub type yew_nav_link::NavIcon::Properties = yew_nav_link::NavIconProps
+pub fn yew_nav_link::NavIcon::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavIconProps
+pub yew_nav_link::components::NavIconProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavIconProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavIconProps::name: core::option::Option<&'static str>
+pub yew_nav_link::components::NavIconProps::size: yew_nav_link::NavIconSize
+impl yew::html::component::properties::Properties for yew_nav_link::NavIconProps
+pub type yew_nav_link::NavIconProps::Builder = NavIconPropsBuilder
+pub fn yew_nav_link::NavIconProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavLinkWithIcon
+impl yew::functional::FunctionProvider for yew_nav_link::NavLinkWithIcon
+pub type yew_nav_link::NavLinkWithIcon::Properties = yew_nav_link::NavLinkWithIconProps
+pub fn yew_nav_link::NavLinkWithIcon::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavLinkWithIconProps
+pub yew_nav_link::components::NavLinkWithIconProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavLinkWithIconProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavLinkWithIconProps::icon: yew_nav_link::NavIconSize
+impl yew::html::component::properties::Properties for yew_nav_link::NavLinkWithIconProps
+pub type yew_nav_link::NavLinkWithIconProps::Builder = NavLinkWithIconPropsBuilder
+pub fn yew_nav_link::NavLinkWithIconProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavTab
+impl yew::functional::FunctionProvider for yew_nav_link::NavTab
+pub type yew_nav_link::NavTab::Properties = yew_nav_link::NavTabProps
+pub fn yew_nav_link::NavTab::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavTabPanel
+impl yew::functional::FunctionProvider for yew_nav_link::NavTabPanel
+pub type yew_nav_link::NavTabPanel::Properties = yew_nav_link::NavTabPanelProps
+pub fn yew_nav_link::NavTabPanel::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavTabPanelProps
+pub yew_nav_link::components::NavTabPanelProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavTabPanelProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavTabPanelProps::hidden: bool
+pub yew_nav_link::components::NavTabPanelProps::id: core::option::Option<&'static str>
+pub yew_nav_link::components::NavTabPanelProps::labelled_by: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavTabPanelProps
+pub type yew_nav_link::NavTabPanelProps::Builder = NavTabPanelPropsBuilder
+pub fn yew_nav_link::NavTabPanelProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavTabProps
+pub yew_nav_link::components::NavTabProps::active: bool
+pub yew_nav_link::components::NavTabProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavTabProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavTabProps::disabled: bool
+pub yew_nav_link::components::NavTabProps::id: core::option::Option<&'static str>
+pub yew_nav_link::components::NavTabProps::onclick: core::option::Option<yew::callback::Callback<web_sys::features::gen_MouseEvent::MouseEvent>>
+pub yew_nav_link::components::NavTabProps::panel_id: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavTabProps
+pub type yew_nav_link::NavTabProps::Builder = NavTabPropsBuilder
+pub fn yew_nav_link::NavTabProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavTabs
+impl yew::functional::FunctionProvider for yew_nav_link::NavTabs
+pub type yew_nav_link::NavTabs::Properties = yew_nav_link::NavTabsProps
+pub fn yew_nav_link::NavTabs::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavTabsProps
+pub yew_nav_link::components::NavTabsProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::NavTabsProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavTabsProps::full_width: bool
+pub yew_nav_link::components::NavTabsProps::id: core::option::Option<&'static str>
+pub yew_nav_link::components::NavTabsProps::role: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavTabsProps
+pub type yew_nav_link::NavTabsProps::Builder = NavTabsPropsBuilder
+pub fn yew_nav_link::NavTabsProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::NavText
+impl yew::functional::FunctionProvider for yew_nav_link::NavText
+pub type yew_nav_link::NavText::Properties = yew_nav_link::NavTextProps
+pub fn yew_nav_link::NavText::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::NavTextProps
+pub yew_nav_link::components::NavTextProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::NavTextProps::text: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavTextProps
+pub type yew_nav_link::NavTextProps::Builder = NavTextPropsBuilder
+pub fn yew_nav_link::NavTextProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::PageItem
+impl yew::functional::FunctionProvider for yew_nav_link::PageItem
+pub type yew_nav_link::PageItem::Properties = yew_nav_link::PageItemProps
+pub fn yew_nav_link::PageItem::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::PageItemProps
+pub yew_nav_link::components::PageItemProps::active: bool
+pub yew_nav_link::components::PageItemProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::PageItemProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::PageItemProps::disabled: bool
+pub yew_nav_link::components::PageItemProps::page: u32
+impl yew::html::component::properties::Properties for yew_nav_link::PageItemProps
+pub type yew_nav_link::PageItemProps::Builder = PageItemPropsBuilder
+pub fn yew_nav_link::PageItemProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::PageLink
+impl yew::functional::FunctionProvider for yew_nav_link::PageLink
+pub type yew_nav_link::PageLink::Properties = yew_nav_link::PageLinkProps
+pub fn yew_nav_link::PageLink::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::PageLinkProps
+pub yew_nav_link::components::PageLinkProps::children: yew::html::component::children::Children
+pub yew_nav_link::components::PageLinkProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::PageLinkProps::href: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::PageLinkProps
+pub type yew_nav_link::PageLinkProps::Builder = PageLinkPropsBuilder
+pub fn yew_nav_link::PageLinkProps::builder() -> Self::Builder
+pub struct yew_nav_link::components::Pagination
+impl yew::functional::FunctionProvider for yew_nav_link::Pagination
+pub type yew_nav_link::Pagination::Properties = yew_nav_link::PaginationProps
+pub fn yew_nav_link::Pagination::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::components::PaginationProps
+pub yew_nav_link::components::PaginationProps::classes: yew::html::classes::Classes
+pub yew_nav_link::components::PaginationProps::current_page: u32
+pub yew_nav_link::components::PaginationProps::on_page_change: core::option::Option<yew::callback::Callback<u32>>
+pub yew_nav_link::components::PaginationProps::show_first_last: bool
+pub yew_nav_link::components::PaginationProps::show_prev_next: bool
+pub yew_nav_link::components::PaginationProps::siblings: u32
+pub yew_nav_link::components::PaginationProps::total_pages: u32
+impl core::default::Default for yew_nav_link::PaginationProps
+pub fn yew_nav_link::PaginationProps::default() -> Self
+impl yew::html::component::properties::Properties for yew_nav_link::PaginationProps
+pub type yew_nav_link::PaginationProps::Builder = PaginationPropsBuilder
+pub fn yew_nav_link::PaginationProps::builder() -> Self::Builder
+pub mod yew_nav_link::errors
+#[non_exhaustive] pub enum yew_nav_link::errors::NavError
+pub yew_nav_link::errors::NavError::InvalidRoute(alloc::string::String)
+pub yew_nav_link::errors::NavError::NavigationCancelled
+pub yew_nav_link::errors::NavError::RouteNotFound
+impl yew_nav_link::errors::NavError
+pub fn yew_nav_link::errors::NavError::invalid_route<S: core::convert::Into<alloc::string::String>>(msg: S) -> Self
+pub const fn yew_nav_link::errors::NavError::navigation_cancelled() -> Self
+pub const fn yew_nav_link::errors::NavError::route_not_found() -> Self
+impl core::error::Error for yew_nav_link::errors::NavError
+impl core::fmt::Display for yew_nav_link::errors::NavError
+pub fn yew_nav_link::errors::NavError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub type yew_nav_link::errors::NavResult<T> = core::result::Result<T, yew_nav_link::errors::NavError>
+pub mod yew_nav_link::hooks
+pub mod yew_nav_link::hooks::use_navigation
+pub struct yew_nav_link::hooks::use_navigation::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub yew_nav_link::hooks::use_navigation::Navigation::_marker: core::marker::PhantomData<R>
+pub yew_nav_link::hooks::use_navigation::Navigation::go_back: yew::callback::Callback<()>
+pub yew_nav_link::hooks::use_navigation::Navigation::go_forward: yew::callback::Callback<()>
+impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub fn yew_nav_link::Navigation<R>::go_callback(&self, delta: isize) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::push_callback(&self, route: R) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::replace_callback(&self, route: R) -> yew::callback::Callback<()>
+pub fn yew_nav_link::hooks::use_navigation::use_navigation<'hook, R>() -> impl 'hook + yew::functional::hooks::Hook<Output = yew_nav_link::Navigation<R>> where R: yew_router::routable::Routable + core::clone::Clone + 'static + 'hook
+pub struct yew_nav_link::hooks::BreadcrumbItem<R>
+pub yew_nav_link::hooks::BreadcrumbItem::is_active: bool
+pub yew_nav_link::hooks::BreadcrumbItem::label: alloc::string::String
+pub yew_nav_link::hooks::BreadcrumbItem::route: R
+pub struct yew_nav_link::hooks::BreadcrumbLabelProviderContext(_)
+impl yew_nav_link::BreadcrumbLabelProviderContext
+pub fn yew_nav_link::BreadcrumbLabelProviderContext::new(provider: alloc::rc::Rc<dyn yew_nav_link::BreadcrumbLabelProvider>) -> Self
+pub fn yew_nav_link::BreadcrumbLabelProviderContext::provider(&self) -> alloc::rc::Rc<dyn yew_nav_link::BreadcrumbLabelProvider>
+impl core::cmp::PartialEq for yew_nav_link::BreadcrumbLabelProviderContext
+pub fn yew_nav_link::BreadcrumbLabelProviderContext::eq(&self, other: &Self) -> bool
+pub struct yew_nav_link::hooks::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub yew_nav_link::hooks::Navigation::_marker: core::marker::PhantomData<R>
+pub yew_nav_link::hooks::Navigation::go_back: yew::callback::Callback<()>
+pub yew_nav_link::hooks::Navigation::go_forward: yew::callback::Callback<()>
+impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub fn yew_nav_link::Navigation<R>::go_callback(&self, delta: isize) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::push_callback(&self, route: R) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::replace_callback(&self, route: R) -> yew::callback::Callback<()>
+pub trait yew_nav_link::hooks::BreadcrumbLabelProvider: core::marker::Send + core::marker::Sync
+pub fn yew_nav_link::hooks::BreadcrumbLabelProvider::label_for_path(&self, path: &str) -> alloc::string::String
+pub fn yew_nav_link::hooks::use_breadcrumbs<'hook, R>() -> impl 'hook + yew::functional::hooks::Hook<Output = alloc::vec::Vec<yew_nav_link::BreadcrumbItem<R>>> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::hooks::use_is_active<'hook, R>(route: R) -> impl 'hook + yew::functional::hooks::Hook<Output = bool> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::hooks::use_is_exact_active<'hook, R>(route: R) -> impl 'hook + yew::functional::hooks::Hook<Output = bool> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::hooks::use_is_partial_active<'hook, R>(route: R) -> impl 'hook + yew::functional::hooks::Hook<Output = bool> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::hooks::use_navigation<'hook, R>() -> impl 'hook + yew::functional::hooks::Hook<Output = yew_nav_link::Navigation<R>> where R: yew_router::routable::Routable + core::clone::Clone + 'static + 'hook
+pub fn yew_nav_link::hooks::use_query_params<'hook>() -> impl 'hook + yew::functional::hooks::Hook<Output = yew_nav_link::utils::QueryParams>
+pub fn yew_nav_link::hooks::use_route_info<'hook, R: yew_router::routable::Routable + 'static + 'hook>() -> impl 'hook + yew::functional::hooks::Hook<Output = core::option::Option<R>>
+pub mod yew_nav_link::nav
+pub struct yew_nav_link::nav::NavDivider
+impl yew::functional::FunctionProvider for yew_nav_link::NavDivider
+pub type yew_nav_link::NavDivider::Properties = yew_nav_link::NavDividerProps
+pub fn yew_nav_link::NavDivider::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::nav::NavDividerProps
+pub yew_nav_link::nav::NavDividerProps::classes: yew::html::classes::Classes
+pub yew_nav_link::nav::NavDividerProps::text: core::option::Option<&'static str>
+pub yew_nav_link::nav::NavDividerProps::vertical: bool
+impl yew::html::component::properties::Properties for yew_nav_link::NavDividerProps
+pub type yew_nav_link::NavDividerProps::Builder = NavDividerPropsBuilder
+pub fn yew_nav_link::NavDividerProps::builder() -> Self::Builder
+pub struct yew_nav_link::nav::NavItem
+impl yew::functional::FunctionProvider for yew_nav_link::NavItem
+pub type yew_nav_link::NavItem::Properties = yew_nav_link::NavItemProps
+pub fn yew_nav_link::NavItem::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::nav::NavItemProps
+pub yew_nav_link::nav::NavItemProps::children: yew::html::component::children::Children
+pub yew_nav_link::nav::NavItemProps::classes: yew::html::classes::Classes
+pub yew_nav_link::nav::NavItemProps::disabled: bool
+impl yew::html::component::properties::Properties for yew_nav_link::NavItemProps
+pub type yew_nav_link::NavItemProps::Builder = NavItemPropsBuilder
+pub fn yew_nav_link::NavItemProps::builder() -> Self::Builder
+pub struct yew_nav_link::nav::NavList
+impl yew::functional::FunctionProvider for yew_nav_link::NavList
+pub type yew_nav_link::NavList::Properties = yew_nav_link::NavListProps
+pub fn yew_nav_link::NavList::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::nav::NavListProps
+pub yew_nav_link::nav::NavListProps::aria_label: core::option::Option<&'static str>
+pub yew_nav_link::nav::NavListProps::children: yew::html::component::children::Children
+pub yew_nav_link::nav::NavListProps::classes: yew::html::classes::Classes
+pub yew_nav_link::nav::NavListProps::id: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavListProps
+pub type yew_nav_link::NavListProps::Builder = NavListPropsBuilder
+pub fn yew_nav_link::NavListProps::builder() -> Self::Builder
+pub mod yew_nav_link::nav_link
+pub struct yew_nav_link::nav_link::NavLink<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>
+impl<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static> yew::functional::FunctionProvider for yew_nav_link::active_link::nav_link::NavLink<R>
+pub type yew_nav_link::active_link::nav_link::NavLink<R>::Properties = yew_nav_link::active_link::props::NavLinkProps<R>
+pub fn yew_nav_link::active_link::nav_link::NavLink<R>::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub fn yew_nav_link::nav_link::nav_link<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>(to: R, children: &str, match_mode: yew_nav_link::active_link::mode::Match) -> yew::html::Html
+pub mod yew_nav_link::use_navigation
+pub struct yew_nav_link::use_navigation::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub yew_nav_link::use_navigation::Navigation::_marker: core::marker::PhantomData<R>
+pub yew_nav_link::use_navigation::Navigation::go_back: yew::callback::Callback<()>
+pub yew_nav_link::use_navigation::Navigation::go_forward: yew::callback::Callback<()>
+impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub fn yew_nav_link::Navigation<R>::go_callback(&self, delta: isize) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::push_callback(&self, route: R) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::replace_callback(&self, route: R) -> yew::callback::Callback<()>
+pub fn yew_nav_link::use_navigation::use_navigation<'hook, R>() -> impl 'hook + yew::functional::hooks::Hook<Output = yew_nav_link::Navigation<R>> where R: yew_router::routable::Routable + core::clone::Clone + 'static + 'hook
+pub mod yew_nav_link::utils
+pub enum yew_nav_link::utils::KeyboardDirection
+pub yew_nav_link::utils::KeyboardDirection::Backward
+pub yew_nav_link::utils::KeyboardDirection::Forward
+pub struct yew_nav_link::utils::KeyboardNavConfig
+pub yew_nav_link::utils::KeyboardNavConfig::vertical: bool
+pub yew_nav_link::utils::KeyboardNavConfig::wrap: bool
+impl yew_nav_link::utils::KeyboardNavConfig
+pub const fn yew_nav_link::utils::KeyboardNavConfig::new() -> Self
+pub const fn yew_nav_link::utils::KeyboardNavConfig::with_vertical(self, vertical: bool) -> Self
+pub const fn yew_nav_link::utils::KeyboardNavConfig::with_wrap(self, wrap: bool) -> Self
+pub struct yew_nav_link::utils::QueryParams
+impl yew_nav_link::utils::QueryParams
+pub fn yew_nav_link::utils::QueryParams::contains_key(&self, key: &str) -> bool
+pub fn yew_nav_link::utils::QueryParams::get(&self, key: &str) -> core::option::Option<&str>
+pub fn yew_nav_link::utils::QueryParams::get_all(&self, key: &str) -> core::option::Option<&alloc::vec::Vec<alloc::string::String>>
+pub fn yew_nav_link::utils::QueryParams::get_one(&self, key: &str) -> core::option::Option<&str>
+pub fn yew_nav_link::utils::QueryParams::has(&self, key: &str) -> bool
+pub fn yew_nav_link::utils::QueryParams::is_empty(&self) -> bool
+pub fn yew_nav_link::utils::QueryParams::iter(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&str, &str)>
+pub fn yew_nav_link::utils::QueryParams::iter_all(&self) -> impl core::iter::traits::iterator::Iterator<Item = (&str, &str)>
+pub fn yew_nav_link::utils::QueryParams::keys(&self) -> impl core::iter::traits::iterator::Iterator<Item = &str>
+pub fn yew_nav_link::utils::QueryParams::len(&self) -> usize
+pub fn yew_nav_link::utils::QueryParams::new() -> Self
+pub fn yew_nav_link::utils::QueryParams::parse(query: &str) -> Self
+pub fn yew_nav_link::utils::QueryParams::remove(&mut self, key: &str)
+pub fn yew_nav_link::utils::QueryParams::set(&mut self, key: &str, value: &str)
+pub fn yew_nav_link::utils::QueryParams::set_value(&mut self, key: &str, value: &str)
+pub fn yew_nav_link::utils::QueryParams::to_query_string(&self) -> alloc::string::String
+pub fn yew_nav_link::utils::QueryParams::values(&self) -> impl core::iter::traits::iterator::Iterator<Item = &str>
+impl core::fmt::Display for yew_nav_link::utils::QueryParams
+pub fn yew_nav_link::utils::QueryParams::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub struct yew_nav_link::utils::UrlParts
+pub yew_nav_link::utils::UrlParts::fragment: core::option::Option<alloc::string::String>
+pub yew_nav_link::utils::UrlParts::host: core::option::Option<alloc::string::String>
+pub yew_nav_link::utils::UrlParts::path: alloc::string::String
+pub yew_nav_link::utils::UrlParts::port: core::option::Option<alloc::string::String>
+pub yew_nav_link::utils::UrlParts::query: core::option::Option<alloc::string::String>
+pub yew_nav_link::utils::UrlParts::scheme: core::option::Option<alloc::string::String>
+impl yew_nav_link::utils::UrlParts
+pub fn yew_nav_link::utils::UrlParts::parse(url: &str) -> Self
+pub fn yew_nav_link::utils::UrlParts::query_params(&self) -> core::option::Option<yew_nav_link::utils::QueryParams>
+pub fn yew_nav_link::utils::handle_arrow_key(key: &str, current_index: usize, total_items: usize, config: &yew_nav_link::utils::KeyboardNavConfig) -> core::option::Option<usize>
+pub fn yew_nav_link::utils::handle_home_end(key: &str, _current_index: usize, total_items: usize) -> core::option::Option<usize>
+pub fn yew_nav_link::utils::is_absolute(path: &str) -> bool
+pub fn yew_nav_link::utils::is_activation_key(key: &str) -> bool
+pub fn yew_nav_link::utils::is_navigation_key(key: &str) -> bool
+pub fn yew_nav_link::utils::join_paths(base: &str, path: &str) -> alloc::string::String
+pub fn yew_nav_link::utils::normalize_path(path: &str) -> alloc::string::String
+pub fn yew_nav_link::utils::urlencoding_decode(input: &str) -> core::option::Option<alloc::string::String>
+pub fn yew_nav_link::utils::urlencoding_encode(input: &str) -> alloc::string::String
+pub enum yew_nav_link::Match
+pub yew_nav_link::Match::Exact
+pub yew_nav_link::Match::Partial
+impl core::fmt::Display for yew_nav_link::active_link::mode::Match
+pub fn yew_nav_link::active_link::mode::Match::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+#[non_exhaustive] pub enum yew_nav_link::NavError
+pub yew_nav_link::NavError::InvalidRoute(alloc::string::String)
+pub yew_nav_link::NavError::NavigationCancelled
+pub yew_nav_link::NavError::RouteNotFound
+impl yew_nav_link::errors::NavError
+pub fn yew_nav_link::errors::NavError::invalid_route<S: core::convert::Into<alloc::string::String>>(msg: S) -> Self
+pub const fn yew_nav_link::errors::NavError::navigation_cancelled() -> Self
+pub const fn yew_nav_link::errors::NavError::route_not_found() -> Self
+impl core::error::Error for yew_nav_link::errors::NavError
+impl core::fmt::Display for yew_nav_link::errors::NavError
+pub fn yew_nav_link::errors::NavError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub enum yew_nav_link::NavIconSize
+pub yew_nav_link::NavIconSize::Large
+pub yew_nav_link::NavIconSize::Medium
+pub yew_nav_link::NavIconSize::Small
+pub struct yew_nav_link::BreadcrumbItem<R>
+pub yew_nav_link::BreadcrumbItem::is_active: bool
+pub yew_nav_link::BreadcrumbItem::label: alloc::string::String
+pub yew_nav_link::BreadcrumbItem::route: R
+pub struct yew_nav_link::BreadcrumbLabelProviderContext(_)
+impl yew_nav_link::BreadcrumbLabelProviderContext
+pub fn yew_nav_link::BreadcrumbLabelProviderContext::new(provider: alloc::rc::Rc<dyn yew_nav_link::BreadcrumbLabelProvider>) -> Self
+pub fn yew_nav_link::BreadcrumbLabelProviderContext::provider(&self) -> alloc::rc::Rc<dyn yew_nav_link::BreadcrumbLabelProvider>
+impl core::cmp::PartialEq for yew_nav_link::BreadcrumbLabelProviderContext
+pub fn yew_nav_link::BreadcrumbLabelProviderContext::eq(&self, other: &Self) -> bool
+pub struct yew_nav_link::NavBadge
+impl yew::functional::FunctionProvider for yew_nav_link::NavBadge
+pub type yew_nav_link::NavBadge::Properties = yew_nav_link::NavBadgeProps
+pub fn yew_nav_link::NavBadge::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavBadgeProps
+pub yew_nav_link::NavBadgeProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavBadgeProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavBadgeProps::pill: bool
+pub yew_nav_link::NavBadgeProps::variant: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavBadgeProps
+pub type yew_nav_link::NavBadgeProps::Builder = NavBadgePropsBuilder
+pub fn yew_nav_link::NavBadgeProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavDivider
+impl yew::functional::FunctionProvider for yew_nav_link::NavDivider
+pub type yew_nav_link::NavDivider::Properties = yew_nav_link::NavDividerProps
+pub fn yew_nav_link::NavDivider::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavDividerProps
+pub yew_nav_link::NavDividerProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavDividerProps::text: core::option::Option<&'static str>
+pub yew_nav_link::NavDividerProps::vertical: bool
+impl yew::html::component::properties::Properties for yew_nav_link::NavDividerProps
+pub type yew_nav_link::NavDividerProps::Builder = NavDividerPropsBuilder
+pub fn yew_nav_link::NavDividerProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavDropdown
+impl yew::functional::FunctionProvider for yew_nav_link::NavDropdown
+pub type yew_nav_link::NavDropdown::Properties = yew_nav_link::NavDropdownProps
+pub fn yew_nav_link::NavDropdown::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavDropdownDivider
+impl yew::functional::FunctionProvider for yew_nav_link::NavDropdownDivider
+pub type yew_nav_link::NavDropdownDivider::Properties = yew_nav_link::components::NavDropdownDividerProps
+pub fn yew_nav_link::NavDropdownDivider::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavDropdownItem
+impl yew::functional::FunctionProvider for yew_nav_link::NavDropdownItem
+pub type yew_nav_link::NavDropdownItem::Properties = yew_nav_link::components::NavDropdownItemProps
+pub fn yew_nav_link::NavDropdownItem::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavDropdownProps
+pub yew_nav_link::NavDropdownProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavDropdownProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavDropdownProps::id: core::option::Option<&'static str>
+pub yew_nav_link::NavDropdownProps::toggle_text: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavDropdownProps
+pub type yew_nav_link::NavDropdownProps::Builder = NavDropdownPropsBuilder
+pub fn yew_nav_link::NavDropdownProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavHeader
+impl yew::functional::FunctionProvider for yew_nav_link::NavHeader
+pub type yew_nav_link::NavHeader::Properties = yew_nav_link::NavHeaderProps
+pub fn yew_nav_link::NavHeader::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavHeaderProps
+pub yew_nav_link::NavHeaderProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavHeaderProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavHeaderProps::text: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavHeaderProps
+pub type yew_nav_link::NavHeaderProps::Builder = NavHeaderPropsBuilder
+pub fn yew_nav_link::NavHeaderProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavIcon
+impl yew::functional::FunctionProvider for yew_nav_link::NavIcon
+pub type yew_nav_link::NavIcon::Properties = yew_nav_link::NavIconProps
+pub fn yew_nav_link::NavIcon::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavIconProps
+pub yew_nav_link::NavIconProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavIconProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavIconProps::name: core::option::Option<&'static str>
+pub yew_nav_link::NavIconProps::size: yew_nav_link::NavIconSize
+impl yew::html::component::properties::Properties for yew_nav_link::NavIconProps
+pub type yew_nav_link::NavIconProps::Builder = NavIconPropsBuilder
+pub fn yew_nav_link::NavIconProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavItem
+impl yew::functional::FunctionProvider for yew_nav_link::NavItem
+pub type yew_nav_link::NavItem::Properties = yew_nav_link::NavItemProps
+pub fn yew_nav_link::NavItem::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavItemAttrs
+pub yew_nav_link::NavItemAttrs::class: yew::html::classes::Classes
+pub yew_nav_link::NavItemAttrs::disabled: bool
+pub yew_nav_link::NavItemAttrs::id: core::option::Option<&'static str>
+pub yew_nav_link::NavItemAttrs::role: core::option::Option<&'static str>
+impl yew_nav_link::attrs::NavItemAttrs
+pub const fn yew_nav_link::attrs::NavItemAttrs::disabled(self) -> Self
+pub fn yew_nav_link::attrs::NavItemAttrs::new() -> Self
+pub fn yew_nav_link::attrs::NavItemAttrs::with_class(self, class: impl core::convert::Into<yew::html::classes::Classes>) -> Self
+pub const fn yew_nav_link::attrs::NavItemAttrs::with_id(self, id: &'static str) -> Self
+pub const fn yew_nav_link::attrs::NavItemAttrs::with_role(self, value: &'static str) -> Self
+pub struct yew_nav_link::NavItemProps
+pub yew_nav_link::NavItemProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavItemProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavItemProps::disabled: bool
+impl yew::html::component::properties::Properties for yew_nav_link::NavItemProps
+pub type yew_nav_link::NavItemProps::Builder = NavItemPropsBuilder
+pub fn yew_nav_link::NavItemProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavLink<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>
+impl<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static> yew::functional::FunctionProvider for yew_nav_link::active_link::nav_link::NavLink<R>
+pub type yew_nav_link::active_link::nav_link::NavLink<R>::Properties = yew_nav_link::active_link::props::NavLinkProps<R>
+pub fn yew_nav_link::active_link::nav_link::NavLink<R>::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavLinkAttrs
+pub yew_nav_link::NavLinkAttrs::aria_current: core::option::Option<&'static str>
+pub yew_nav_link::NavLinkAttrs::class: yew::html::classes::Classes
+pub yew_nav_link::NavLinkAttrs::data_toggle: core::option::Option<&'static str>
+pub yew_nav_link::NavLinkAttrs::id: core::option::Option<&'static str>
+pub yew_nav_link::NavLinkAttrs::role: core::option::Option<&'static str>
+impl yew_nav_link::attrs::NavLinkAttrs
+pub fn yew_nav_link::attrs::NavLinkAttrs::new() -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_aria_current(self, value: &'static str) -> Self
+pub fn yew_nav_link::attrs::NavLinkAttrs::with_class(self, class: impl core::convert::Into<yew::html::classes::Classes>) -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_data_toggle(self, value: &'static str) -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_id(self, id: &'static str) -> Self
+pub const fn yew_nav_link::attrs::NavLinkAttrs::with_role(self, value: &'static str) -> Self
+pub struct yew_nav_link::NavLinkProps<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>
+pub yew_nav_link::NavLinkProps::active_class: &'static str
+pub yew_nav_link::NavLinkProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavLinkProps::class: &'static str
+pub yew_nav_link::NavLinkProps::partial: bool
+pub yew_nav_link::NavLinkProps::to: R
+impl<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static> yew::html::component::properties::Properties for yew_nav_link::active_link::props::NavLinkProps<R>
+pub type yew_nav_link::active_link::props::NavLinkProps<R>::Builder = NavLinkPropsBuilder<R>
+pub fn yew_nav_link::active_link::props::NavLinkProps<R>::builder() -> Self::Builder
+pub struct yew_nav_link::NavLinkWithIcon
+impl yew::functional::FunctionProvider for yew_nav_link::NavLinkWithIcon
+pub type yew_nav_link::NavLinkWithIcon::Properties = yew_nav_link::NavLinkWithIconProps
+pub fn yew_nav_link::NavLinkWithIcon::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavLinkWithIconProps
+pub yew_nav_link::NavLinkWithIconProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavLinkWithIconProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavLinkWithIconProps::icon: yew_nav_link::NavIconSize
+impl yew::html::component::properties::Properties for yew_nav_link::NavLinkWithIconProps
+pub type yew_nav_link::NavLinkWithIconProps::Builder = NavLinkWithIconPropsBuilder
+pub fn yew_nav_link::NavLinkWithIconProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavList
+impl yew::functional::FunctionProvider for yew_nav_link::NavList
+pub type yew_nav_link::NavList::Properties = yew_nav_link::NavListProps
+pub fn yew_nav_link::NavList::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavListAttrs
+pub yew_nav_link::NavListAttrs::aria_label: core::option::Option<&'static str>
+pub yew_nav_link::NavListAttrs::class: yew::html::classes::Classes
+pub yew_nav_link::NavListAttrs::id: core::option::Option<&'static str>
+impl yew_nav_link::attrs::NavListAttrs
+pub fn yew_nav_link::attrs::NavListAttrs::new() -> Self
+pub const fn yew_nav_link::attrs::NavListAttrs::with_aria_label(self, label: &'static str) -> Self
+pub fn yew_nav_link::attrs::NavListAttrs::with_class(self, class: impl core::convert::Into<yew::html::classes::Classes>) -> Self
+pub const fn yew_nav_link::attrs::NavListAttrs::with_id(self, id: &'static str) -> Self
+pub struct yew_nav_link::NavListProps
+pub yew_nav_link::NavListProps::aria_label: core::option::Option<&'static str>
+pub yew_nav_link::NavListProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavListProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavListProps::id: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavListProps
+pub type yew_nav_link::NavListProps::Builder = NavListPropsBuilder
+pub fn yew_nav_link::NavListProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavTab
+impl yew::functional::FunctionProvider for yew_nav_link::NavTab
+pub type yew_nav_link::NavTab::Properties = yew_nav_link::NavTabProps
+pub fn yew_nav_link::NavTab::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavTabPanel
+impl yew::functional::FunctionProvider for yew_nav_link::NavTabPanel
+pub type yew_nav_link::NavTabPanel::Properties = yew_nav_link::NavTabPanelProps
+pub fn yew_nav_link::NavTabPanel::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavTabPanelProps
+pub yew_nav_link::NavTabPanelProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavTabPanelProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavTabPanelProps::hidden: bool
+pub yew_nav_link::NavTabPanelProps::id: core::option::Option<&'static str>
+pub yew_nav_link::NavTabPanelProps::labelled_by: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavTabPanelProps
+pub type yew_nav_link::NavTabPanelProps::Builder = NavTabPanelPropsBuilder
+pub fn yew_nav_link::NavTabPanelProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavTabProps
+pub yew_nav_link::NavTabProps::active: bool
+pub yew_nav_link::NavTabProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavTabProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavTabProps::disabled: bool
+pub yew_nav_link::NavTabProps::id: core::option::Option<&'static str>
+pub yew_nav_link::NavTabProps::onclick: core::option::Option<yew::callback::Callback<web_sys::features::gen_MouseEvent::MouseEvent>>
+pub yew_nav_link::NavTabProps::panel_id: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::NavTabProps
+pub type yew_nav_link::NavTabProps::Builder = NavTabPropsBuilder
+pub fn yew_nav_link::NavTabProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavTabs
+impl yew::functional::FunctionProvider for yew_nav_link::NavTabs
+pub type yew_nav_link::NavTabs::Properties = yew_nav_link::NavTabsProps
+pub fn yew_nav_link::NavTabs::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavTabsProps
+pub yew_nav_link::NavTabsProps::children: yew::html::component::children::Children
+pub yew_nav_link::NavTabsProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavTabsProps::full_width: bool
+pub yew_nav_link::NavTabsProps::id: core::option::Option<&'static str>
+pub yew_nav_link::NavTabsProps::role: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavTabsProps
+pub type yew_nav_link::NavTabsProps::Builder = NavTabsPropsBuilder
+pub fn yew_nav_link::NavTabsProps::builder() -> Self::Builder
+pub struct yew_nav_link::NavText
+impl yew::functional::FunctionProvider for yew_nav_link::NavText
+pub type yew_nav_link::NavText::Properties = yew_nav_link::NavTextProps
+pub fn yew_nav_link::NavText::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::NavTextProps
+pub yew_nav_link::NavTextProps::classes: yew::html::classes::Classes
+pub yew_nav_link::NavTextProps::text: &'static str
+impl yew::html::component::properties::Properties for yew_nav_link::NavTextProps
+pub type yew_nav_link::NavTextProps::Builder = NavTextPropsBuilder
+pub fn yew_nav_link::NavTextProps::builder() -> Self::Builder
+pub struct yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub yew_nav_link::Navigation::_marker: core::marker::PhantomData<R>
+pub yew_nav_link::Navigation::go_back: yew::callback::Callback<()>
+pub yew_nav_link::Navigation::go_forward: yew::callback::Callback<()>
+impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
+pub fn yew_nav_link::Navigation<R>::go_callback(&self, delta: isize) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::push_callback(&self, route: R) -> yew::callback::Callback<()>
+pub fn yew_nav_link::Navigation<R>::replace_callback(&self, route: R) -> yew::callback::Callback<()>
+pub struct yew_nav_link::PageItem
+impl yew::functional::FunctionProvider for yew_nav_link::PageItem
+pub type yew_nav_link::PageItem::Properties = yew_nav_link::PageItemProps
+pub fn yew_nav_link::PageItem::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::PageItemProps
+pub yew_nav_link::PageItemProps::active: bool
+pub yew_nav_link::PageItemProps::children: yew::html::component::children::Children
+pub yew_nav_link::PageItemProps::classes: yew::html::classes::Classes
+pub yew_nav_link::PageItemProps::disabled: bool
+pub yew_nav_link::PageItemProps::page: u32
+impl yew::html::component::properties::Properties for yew_nav_link::PageItemProps
+pub type yew_nav_link::PageItemProps::Builder = PageItemPropsBuilder
+pub fn yew_nav_link::PageItemProps::builder() -> Self::Builder
+pub struct yew_nav_link::PageLink
+impl yew::functional::FunctionProvider for yew_nav_link::PageLink
+pub type yew_nav_link::PageLink::Properties = yew_nav_link::PageLinkProps
+pub fn yew_nav_link::PageLink::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::PageLinkProps
+pub yew_nav_link::PageLinkProps::children: yew::html::component::children::Children
+pub yew_nav_link::PageLinkProps::classes: yew::html::classes::Classes
+pub yew_nav_link::PageLinkProps::href: core::option::Option<&'static str>
+impl yew::html::component::properties::Properties for yew_nav_link::PageLinkProps
+pub type yew_nav_link::PageLinkProps::Builder = PageLinkPropsBuilder
+pub fn yew_nav_link::PageLinkProps::builder() -> Self::Builder
+pub struct yew_nav_link::Pagination
+impl yew::functional::FunctionProvider for yew_nav_link::Pagination
+pub type yew_nav_link::Pagination::Properties = yew_nav_link::PaginationProps
+pub fn yew_nav_link::Pagination::run(ctx: &mut yew::functional::HookContext, props: &Self::Properties) -> yew::html::HtmlResult
+pub struct yew_nav_link::PaginationProps
+pub yew_nav_link::PaginationProps::classes: yew::html::classes::Classes
+pub yew_nav_link::PaginationProps::current_page: u32
+pub yew_nav_link::PaginationProps::on_page_change: core::option::Option<yew::callback::Callback<u32>>
+pub yew_nav_link::PaginationProps::show_first_last: bool
+pub yew_nav_link::PaginationProps::show_prev_next: bool
+pub yew_nav_link::PaginationProps::siblings: u32
+pub yew_nav_link::PaginationProps::total_pages: u32
+impl core::default::Default for yew_nav_link::PaginationProps
+pub fn yew_nav_link::PaginationProps::default() -> Self
+impl yew::html::component::properties::Properties for yew_nav_link::PaginationProps
+pub type yew_nav_link::PaginationProps::Builder = PaginationPropsBuilder
+pub fn yew_nav_link::PaginationProps::builder() -> Self::Builder
+pub trait yew_nav_link::BreadcrumbLabelProvider: core::marker::Send + core::marker::Sync
+pub fn yew_nav_link::BreadcrumbLabelProvider::label_for_path(&self, path: &str) -> alloc::string::String
+pub fn yew_nav_link::is_absolute(path: &str) -> bool
+pub fn yew_nav_link::join_paths(base: &str, path: &str) -> alloc::string::String
+pub fn yew_nav_link::nav_link<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>(to: R, children: &str, match_mode: yew_nav_link::active_link::mode::Match) -> yew::html::Html
+pub fn yew_nav_link::normalize_path(path: &str) -> alloc::string::String
+pub fn yew_nav_link::use_breadcrumbs<'hook, R>() -> impl 'hook + yew::functional::hooks::Hook<Output = alloc::vec::Vec<yew_nav_link::BreadcrumbItem<R>>> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::use_is_active<'hook, R>(route: R) -> impl 'hook + yew::functional::hooks::Hook<Output = bool> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::use_is_exact_active<'hook, R>(route: R) -> impl 'hook + yew::functional::hooks::Hook<Output = bool> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::use_is_partial_active<'hook, R>(route: R) -> impl 'hook + yew::functional::hooks::Hook<Output = bool> where R: yew_router::routable::Routable + core::clone::Clone + core::cmp::PartialEq + 'static + 'hook
+pub fn yew_nav_link::use_navigation<'hook, R>() -> impl 'hook + yew::functional::hooks::Hook<Output = yew_nav_link::Navigation<R>> where R: yew_router::routable::Routable + core::clone::Clone + 'static + 'hook
+pub fn yew_nav_link::use_query_params<'hook>() -> impl 'hook + yew::functional::hooks::Hook<Output = yew_nav_link::utils::QueryParams>
+pub fn yew_nav_link::use_route_info<'hook, R: yew_router::routable::Routable + 'static + 'hook>() -> impl 'hook + yew::functional::hooks::Hook<Output = core::option::Option<R>>
+pub type yew_nav_link::NavResult<T> = core::result::Result<T, yew_nav_link::errors::NavError>


### PR DESCRIPTION
Closes #124

## Summary

- `docs/public-api.txt` — 699-line baseline of the public surface produced by `cargo public-api -sss` (skips blanket impls, auto-trait impls, auto-derived impls so the file shows only meaningful items).
- New CI job `Public API` in `.github/workflows/ci.yml`, sitting next to `Semver Checks`. Installs `cargo-public-api` via `taiki-e/install-action`, regenerates the surface, `diff -u`'s against the committed baseline. On drift it appends a markdown diff to `$GITHUB_STEP_SUMMARY` and fails with a one-line `cargo public-api -sss > docs/public-api.txt` fix.
- `CI Success` aggregate updated (`needs`, status table, gating expression).
- `CONTRIBUTING.md` CI overview gains a `Public API` row.

## Why a committed baseline rather than an HEAD↔BASE diff comment

Two reasons:

1. The PR diff already does the work. When `docs/public-api.txt` changes, every reviewer sees the exact public-surface change inline with the source change — no separate comment to look for, no merge race against a stale comment.
2. It pairs with `Semver Checks`: that job rejects breaking signatures; `Public API` makes additive ones impossible to merge without intent. A new `pub fn` without a CHANGELOG entry will land as an unexpected line in `docs/public-api.txt` and surface in review.

The trade-off — contributors regenerate the baseline as part of an API-touching PR — is the friction that creates the visibility.

## Local verification

- `cargo public-api -sss > docs/public-api.txt` — 699 lines, head includes `pub mod yew_nav_link`, `pub enum Match::Exact/Partial`, the full `NavLink<R>` props surface
- `cargo public-api -sss | diff -u docs/public-api.txt -` — clean
- `actionlint .github/workflows/ci.yml` — clean
- `reuse lint` — 134/134 (baseline covered by aggregate annotation in `REUSE.toml`)
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] `Public API` job stays green on this PR (no API change)
- [ ] `CI Success` aggregate green