### PR TITLE
#120 docs: publish architectural docs as mdBook on gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,22 @@ jobs:
       - name: Compare public API against the last crates.io release
         run: cargo semver-checks check-release --verbose
 
+  book:
+    name: Book
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install mdBook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+
+      - name: Build book
+        run: mdbook build docs
+
   public_api:
     name: Public API
     runs-on: ubuntu-latest
@@ -653,7 +669,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [msrv, check, fmt, docs, semver_checks, public_api, no_std, security, reuse, test, wasm_tests, coverage, benchmarks, wasm-build, e2e, lighthouse, changelog, actionlint]
+    needs: [msrv, check, fmt, docs, semver_checks, public_api, book, no_std, security, reuse, test, wasm_tests, coverage, benchmarks, wasm-build, e2e, lighthouse, changelog, actionlint]
     if: always()
     steps:
       - name: Check job status
@@ -666,6 +682,7 @@ jobs:
           echo "  Docs: ${{ needs.docs.result }}"
           echo "  Semver Checks: ${{ needs.semver_checks.result }}"
           echo "  Public API: ${{ needs.public_api.result }}"
+          echo "  Book: ${{ needs.book.result }}"
           echo "  no-std: ${{ needs.no_std.result }}"
           echo "  Security: ${{ needs.security.result }}"
           echo "  REUSE: ${{ needs.reuse.result }}"
@@ -679,7 +696,7 @@ jobs:
           echo "  Changelog: ${{ needs.changelog.result }}"
           echo "  Actionlint: ${{ needs.actionlint.result }}"
 
-          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.public_api.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || "${{ needs.wasm_tests.result }}" != "success" || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.e2e.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
+          if [[ "${{ needs.msrv.result }}" != "success" || "${{ needs.check.result }}" != "success" || "${{ needs.fmt.result }}" != "success" || "${{ needs.docs.result }}" != "success" || "${{ needs.semver_checks.result }}" != "success" || "${{ needs.public_api.result }}" != "success" || "${{ needs.book.result }}" != "success" || "${{ needs.no_std.result }}" != "success" || "${{ needs.security.result }}" != "success" || "${{ needs.reuse.result }}" != "success" || ("${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped") || "${{ needs.wasm_tests.result }}" != "success" || ("${{ needs.coverage.result }}" != "success" && "${{ needs.coverage.result }}" != "skipped") || ("${{ needs.benchmarks.result }}" != "success" && "${{ needs.benchmarks.result }}" != "skipped") || "${{ needs.wasm-build.result }}" != "success" || "${{ needs.e2e.result }}" != "success" || "${{ needs.lighthouse.result }}" != "success" || ("${{ needs.changelog.result }}" != "success" && "${{ needs.changelog.result }}" != "skipped") || "${{ needs.actionlint.result }}" != "success" ]]; then
             echo "❌ CI failed"
             exit 1
           fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,6 +56,19 @@ jobs:
       - name: SPA fallback (copy index.html to 404.html)
         run: cp example/dist/index.html example/dist/404.html
 
+      - name: Install mdBook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+
+      - name: Build book
+        run: mdbook build docs
+
+      - name: Stage book under demo /book/
+        run: |
+          mkdir -p example/dist/book
+          cp -r docs/book/. example/dist/book/
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ target/
 # Trunk build output
 example/dist/
 
+# mdBook build output
+docs/book/
+
 # crates.io archives
 *.crate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,7 @@ merge.
 | `Lint (clippy)` | yes | pedantic + nursery |
 | `Documentation` | yes | `cargo doc --all-features` with `RUSTDOCFLAGS=-D warnings` |
 | `Public API` | yes | `cargo public-api -sss` must match `docs/public-api.txt` |
+| `Book` | yes | `mdbook build docs` against `docs/book.toml` |
 | `no-std` | yes | informational stub (Yew is std-only) |
 | `Security` | yes | `cargo deny check` + `cargo audit` |
 | `REUSE Compliance` | yes | `reuse lint` |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Enterprise-grade navigation library for [Yew](https://yew.rs) — automatic acti
 
 <div align="center">
 
-[**🌐 Live demo →**](https://raprogramm.github.io/yew-nav-link/)
+[**🌐 Live demo →**](https://raprogramm.github.io/yew-nav-link/) — [**📖 Architectural book →**](https://raprogramm.github.io/yew-nav-link/book/)
 
 [![CI](https://github.com/RAprogramm/yew-nav-link/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/yew-nav-link/actions/workflows/ci.yml)
 [![Pages](https://github.com/RAprogramm/yew-nav-link/actions/workflows/pages.yml/badge.svg?branch=main)](https://github.com/RAprogramm/yew-nav-link/actions/workflows/pages.yml)
@@ -404,6 +404,7 @@ pub struct BreadcrumbItem {
 
 | File | Purpose |
 |------|---------|
+| [Architectural book](https://raprogramm.github.io/yew-nav-link/book/) | Rendered mdBook of the documents below — search, syntax-highlighting, navigation. Source lives under `docs/`. |
 | [`docs/REQUIREMENTS.md`](docs/REQUIREMENTS.md) | Functional and non-functional requirements (what the crate does, the constraints under which it does it) |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Module layout, the active-state algorithm, hook contracts, breadcrumb context flow |
 | [`docs/ROADMAP.md`](docs/ROADMAP.md) | Trajectory toward 0.10 (breaking-change pass) and 1.0 (API freeze) |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,28 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Summary
+
+[Introduction](introduction.md)
+
+# Reference
+
+- [Requirements](REQUIREMENTS.md)
+- [Architecture](ARCHITECTURE.md)
+- [Roadmap](ROADMAP.md)
+
+# Process
+
+- [Branching and merge policy](BRANCHING.md)
+
+# Architecture decisions
+
+- [About ADRs](adr/README.md)
+- [0000 — Record architecture decisions](adr/0000-record-architecture-decisions.md)
+- [0001 — `class` and `active_class` are `&'static str`](adr/0001-static-str-classes.md)
+- [0002 — Drop the `macros` feature in 0.9.0](adr/0002-drop-macros-feature.md)
+- [0003 — `NavError` is `#[non_exhaustive]` from 0.10.0](adr/0003-non-exhaustive-nav-error.md)
+- [0004 — Render a manual `<a>` instead of wrapping `yew_router::Link`](adr/0004-manual-anchor-over-yew-router-link.md)
+- [0005 — Active `NavLink` emits `aria-current="page"`](adr/0005-active-state-via-aria-current.md)

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+[book]
+title = "yew-nav-link — architectural reference"
+authors = ["RAprogramm"]
+language = "en"
+src = "."
+
+[build]
+build-dir = "book"
+create-missing = false
+
+[output.html]
+git-repository-url = "https://github.com/RAprogramm/yew-nav-link"
+edit-url-template = "https://github.com/RAprogramm/yew-nav-link/edit/main/docs/{path}"
+default-theme = "navy"
+preferred-dark-theme = "navy"
+no-section-label = false
+
+[output.html.fold]
+enable = true
+level = 1
+
+[output.html.search]
+enable = true
+limit-results = 30
+use-boolean-and = true
+boost-title = 2

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,55 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Introduction
+
+This book is the architectural reference for [`yew-nav-link`][crate]. It
+is not a tutorial — the crate's [`README`][readme] is the place to learn
+*what* the library does and *how* to drop it into your Yew app. The book
+collects the documents that explain *why* the crate is shaped the way
+it is and the contracts it commits to.
+
+[crate]: https://crates.io/crates/yew-nav-link
+[readme]: https://github.com/RAprogramm/yew-nav-link#readme
+
+## What is here
+
+- **[Requirements](REQUIREMENTS.md)** — the functional and non-functional
+  contracts the crate commits to. Every claim in this document is
+  exercised by the test suite, the demo, or the CI pipeline.
+- **[Architecture](ARCHITECTURE.md)** — the module layout, the
+  active-state algorithm, hook contracts, and the breadcrumb context flow.
+- **[Roadmap](ROADMAP.md)** — what is in flight between the current 0.10
+  line and the 1.0 freeze.
+- **[Branching and merge policy](BRANCHING.md)** — how changes reach
+  `main` and what the squash-merge contract is.
+- **[Architecture Decision Records](adr/README.md)** — one MADR file per
+  non-trivial decision. The reasoning behind 0.9 → 0.10 lives here.
+
+## What is *not* here
+
+- API docs. Those live on [docs.rs][docs] and are generated from the
+  crate's source. The book intentionally does not duplicate them.
+- The contributor workflow. That is in
+  [`CONTRIBUTING.md`][contributing] in the repository root.
+- The release procedure. That is in [`RELEASE.md`][release].
+- The changelog. That is in [`CHANGELOG.md`][changelog].
+
+[docs]: https://docs.rs/yew-nav-link
+[contributing]: https://github.com/RAprogramm/yew-nav-link/blob/main/CONTRIBUTING.md
+[release]: https://github.com/RAprogramm/yew-nav-link/blob/main/RELEASE.md
+[changelog]: https://github.com/RAprogramm/yew-nav-link/blob/main/CHANGELOG.md
+
+## How to read this book
+
+ADRs are append-only and small. Read the index first
+([`adr/README.md`](adr/README.md)), pick the decision you want context on,
+and the body answers in roughly one screen. The Reference and Process
+sections are longer prose; read top-to-bottom on first visit, jump back
+to a section by its heading on subsequent visits.
+
+When a record is superseded, it stays in place and the new record marks
+it `superseded by NNNN`. The history is intact — the file index always
+reflects the latest accepted state.


### PR DESCRIPTION
Closes #120

## Summary

- `docs/book.toml` — mdBook config, `src = "."` so the existing `docs/*.md` and `docs/adr/*.md` work without moving files. Includes git-repository-url, edit-url-template, search enabled, foldable TOC.
- `docs/SUMMARY.md` — book outline: Introduction → Reference (Requirements / Architecture / Roadmap) → Process (Branching) → Architecture decisions (ADR index + the six existing records).
- `docs/introduction.md` — new chapter explaining the book's scope and pointing back at the README / docs.rs / CONTRIBUTING / RELEASE / CHANGELOG on GitHub for everything the book deliberately does not cover.
- `.github/workflows/ci.yml` — new `Book` job verifying `mdbook build docs` builds clean. Added to `CI Success` aggregate.
- `.github/workflows/pages.yml` — builds the book alongside the demo and stages it at `example/dist/book/` so it deploys to `https://raprogramm.github.io/yew-nav-link/book/`.
- `.gitignore` — ignore `docs/book/` build output.
- `CONTRIBUTING.md` CI overview gains a `Book` row.
- `README.md` — header gets a `📖 Architectural book →` link next to the live-demo link; `Project documentation` table gains a row pointing at the book.

## Local verification

- `mdbook build docs/` — builds clean, output under `docs/book/`
- `actionlint .github/workflows/ci.yml .github/workflows/pages.yml` — clean
- `reuse lint` — 137/137 files SPDX-tagged
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Out of scope

- Theme customisation beyond `default-theme = "navy"`. Default mdBook chrome is fine for now.
- Migrating standalone markdown to the book root. The current layout keeps GitHub-rendered URLs stable (`docs/REQUIREMENTS.md` still resolves on github.com); the book uses the same files via `src = "."`.

## Test plan

- [ ] `Book` job runs `mdbook build docs` and stays green
- [ ] After merge, Pages workflow stages `docs/book/` under `example/dist/book/`
- [ ] `https://raprogramm.github.io/yew-nav-link/book/` serves the rendered book
- [ ] Demo at site root continues to work