### PR TITLE
#121 ci: nightly cargo-mutants mutation testing job

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# cargo-mutants drives mutation testing for `yew-nav-link`. The defaults
+# inject every supported mutation into every function; this file narrows
+# the scope so the surviving-mutant report stays focused on logic that
+# actually deserves a test, not on derive-generated noise.
+
+# Skip mutations inside the demo crate and the wasm browser tests — the
+# library proper is what the suite gates.
+exclude_globs = [
+  "example/**",
+  "tests/wasm/**",
+  "tests/wasm.rs",
+  "benches/**",
+]
+
+# Skip mutations that flip Debug / Display / Clone implementations and
+# generated trait machinery. Surviving such a mutant is almost always a
+# false positive (the impl is auto-derived or trivially correct).
+exclude_re = [
+  "impl Debug",
+  "impl Display",
+  "impl Clone",
+  "impl PartialEq",
+  "impl Default",
+]

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Mutation testing is the strongest available evidence that line/branch
+# coverage is not coverage theatre. cargo-mutants injects mutations into
+# the source and reports those that survive the test suite — a survived
+# mutant is a behaviour the tests do not exercise.
+#
+# This job runs nightly (cron) and on demand (workflow_dispatch). It is
+# intentionally out of the PR critical path: a single full mutants run
+# can take 30-60 minutes, and the right cadence for the signal is daily,
+# not per-PR.
+
+name: Mutants
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutants-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  mutants:
+    name: cargo-mutants
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Load cached target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: mutants
+          save-if: true
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Run cargo-mutants
+        run: cargo mutants --no-shuffle --timeout-multiplier 2 --output mutants.out
+
+      - name: Append mutants summary to workflow output
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f mutants.out/outcomes.json ]; then
+            total=$(jq '[.outcomes[]] | length' mutants.out/outcomes.json)
+            caught=$(jq '[.outcomes[] | select(.summary == "CaughtMutant")] | length' mutants.out/outcomes.json)
+            missed=$(jq '[.outcomes[] | select(.summary == "MissedMutant")] | length' mutants.out/outcomes.json)
+            timeout=$(jq '[.outcomes[] | select(.summary == "Timeout")] | length' mutants.out/outcomes.json)
+            unviable=$(jq '[.outcomes[] | select(.summary == "Unviable")] | length' mutants.out/outcomes.json)
+            {
+              echo "## Mutation testing"
+              echo
+              printf '| Metric | Count |\n'
+              printf '|---|---:|\n'
+              printf '| Total mutants | %s |\n' "$total"
+              printf '| Caught | %s |\n' "$caught"
+              printf '| Missed (survived) | %s |\n' "$missed"
+              printf '| Timeout | %s |\n' "$timeout"
+              printf '| Unviable | %s |\n' "$unviable"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "(mutants.out/outcomes.json not produced)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload mutants report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-report
+          path: mutants.out/
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Enterprise-grade navigation library for [Yew](https://yew.rs) — automatic acti
 
 [![CI](https://github.com/RAprogramm/yew-nav-link/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RAprogramm/yew-nav-link/actions/workflows/ci.yml)
 [![Pages](https://github.com/RAprogramm/yew-nav-link/actions/workflows/pages.yml/badge.svg?branch=main)](https://github.com/RAprogramm/yew-nav-link/actions/workflows/pages.yml)
+[![Mutants](https://github.com/RAprogramm/yew-nav-link/actions/workflows/mutants.yml/badge.svg?branch=main)](https://github.com/RAprogramm/yew-nav-link/actions/workflows/mutants.yml)
 [![Crates.io](https://img.shields.io/crates/v/yew-nav-link)](https://crates.io/crates/yew-nav-link)
 [![docs.rs](https://img.shields.io/docsrs/yew-nav-link)](https://docs.rs/yew-nav-link)
 [![Downloads](https://img.shields.io/crates/d/yew-nav-link)](https://crates.io/crates/yew-nav-link)


### PR DESCRIPTION
Closes #121

## Summary

- `.github/workflows/mutants.yml` — new workflow on `schedule: cron "0 4 * * *"` plus `workflow_dispatch`. Installs `cargo-mutants` via `taiki-e/install-action`, runs `cargo mutants --no-shuffle --timeout-multiplier 2 --output mutants.out`, summarises caught / missed / timeout / unviable into `$GITHUB_STEP_SUMMARY`, and uploads the full `mutants.out/` as an artifact with 30-day retention.
- `.cargo/mutants.toml` — exclude `example/`, `tests/wasm/`, `benches/`; exclude mutation of derive-generated `impl Debug | Display | Clone | PartialEq | Default` to keep the surviving-mutant report focused on logic that deserves a test.
- `README.md` — badge added next to CI and Pages.

## Why a separate workflow

A full mutants run takes 30-60 minutes — too long for the PR critical path. Nightly cadence is the right tempo: the signal answers "are tests asserting behaviour, or just executing it" and the answer rarely changes in one PR's worth of churn. `workflow_dispatch` is available for one-off investigations.

## Why this signal matters for KaiCode

Codecov gates 95% line coverage, but high line coverage can coexist with tests that never `assert!`. Mutation testing makes that gap visible. Few KaiCode submissions ship it — the jury's "unit testing" dimension benefits.

## Local verification

- `actionlint .github/workflows/mutants.yml` — clean
- `reuse lint` — 139/139 files SPDX-tagged (the two new files use `#`-prefixed SPDX headers per REUSE's YAML/TOML convention)
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] `Mutants` workflow runs on the next nightly cron and completes within the 90 minute timeout
- [ ] Workflow summary shows total / caught / missed / timeout / unviable counts
- [ ] Artifact `mutants-report` uploads regardless of outcome