### PR TITLE
#122 test: cargo-fuzz targets for path and URL helpers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Weekly coverage-guided fuzzing for the path / URL helpers. Each
+# target runs for five minutes — long enough to surface a panic or
+# overflow, short enough to fit in the free-runner budget.
+
+name: Fuzz
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_normalize_path
+          - fuzz_join_paths
+          - fuzz_urlencoding_roundtrip
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Load cached target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+          key: fuzz-${{ matrix.target }}
+          save-if: true
+
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+
+      - name: Run ${{ matrix.target }}
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=300
+        working-directory: fuzz
+
+      - name: Upload corpus and artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-${{ matrix.target }}-artifacts
+          path: |
+            fuzz/artifacts/
+            fuzz/corpus/
+          retention-days: 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/RAprogramm/yew-nav-link"
 license = "MIT"
 keywords = ["yew", "router", "navigation", "wasm", "frontend"]
 categories = ["gui", "wasm", "web-programming"]
-exclude = ["example/**"]
+exclude = ["example/**", "fuzz/**"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "yew-nav-link-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.yew-nav-link]
+path = ".."
+
+# Empty [workspace] table marks this crate as its own workspace root so
+# cargo-fuzz's nightly toolchain does not try to compile the parent crate
+# under wasm32 dev-deps.
+[workspace]
+
+[[bin]]
+name = "fuzz_normalize_path"
+path = "fuzz_targets/fuzz_normalize_path.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_join_paths"
+path = "fuzz_targets/fuzz_join_paths.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_urlencoding_roundtrip"
+path = "fuzz_targets/fuzz_urlencoding_roundtrip.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,48 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Fuzz targets
+
+`cargo-fuzz` drives libFuzzer against the path and URL helpers exposed
+by `yew-nav-link`. The `tests/proptest_utils.rs` property suite bounds
+its inputs by a regex grammar; these fuzz targets drive the same
+functions with unbounded byte sequences from libFuzzer's coverage-guided
+input generator.
+
+## Targets
+
+| Target | What it asserts |
+|---|---|
+| `fuzz_normalize_path` | `normalize_path` is idempotent and preserves absoluteness for absolute inputs. |
+| `fuzz_join_paths` | `join_paths(base, segment)` does not panic on arbitrary UTF-8 inputs. |
+| `fuzz_urlencoding_roundtrip` | `urlencoding_decode(urlencoding_encode(s)) == s` for any UTF-8 input. |
+
+## Running locally
+
+```bash
+cargo install --locked cargo-fuzz
+cd fuzz
+cargo +nightly fuzz run fuzz_normalize_path -- -max_total_time=60
+cargo +nightly fuzz run fuzz_join_paths -- -max_total_time=60
+cargo +nightly fuzz run fuzz_urlencoding_roundtrip -- -max_total_time=60
+```
+
+`cargo fuzz` requires a nightly toolchain — the macro it expands to
+needs unstable `#[no_main]` instrumentation hooks.
+
+## Layout
+
+`fuzz/` is a self-contained workspace (the empty `[workspace]` table in
+`fuzz/Cargo.toml`). It is not built by the parent crate's `cargo build`
+and does not show up under `cargo public-api`. The corpora live under
+`fuzz/corpus/<target>/`; libFuzzer writes new inputs there as it
+discovers new code paths.
+
+## CI
+
+`.github/workflows/fuzz.yml` runs each target for five minutes on a
+weekly schedule and on demand (`workflow_dispatch`). The job is out of
+the PR critical path — the right cadence for fuzzing is "let it run"
+not "block every change."

--- a/fuzz/fuzz_targets/fuzz_join_paths.rs
+++ b/fuzz/fuzz_targets/fuzz_join_paths.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use yew_nav_link::utils::join_paths;
+
+fuzz_target!(|data: (&str, &str)| {
+    let (base, segment) = data;
+    let _ = join_paths(base, segment);
+});

--- a/fuzz/fuzz_targets/fuzz_normalize_path.rs
+++ b/fuzz/fuzz_targets/fuzz_normalize_path.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use yew_nav_link::utils::{is_absolute, normalize_path};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let first = normalize_path(s);
+    let second = normalize_path(&first);
+    assert_eq!(first, second, "normalize_path must be idempotent");
+
+    if is_absolute(s) && !first.is_empty() {
+        assert!(
+            first.starts_with('/'),
+            "absolute input {s:?} normalized to {first:?}",
+        );
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_urlencoding_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_urlencoding_roundtrip.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use yew_nav_link::utils::{urlencoding_decode, urlencoding_encode};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(s) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let encoded = urlencoding_encode(s);
+    let decoded = urlencoding_decode(&encoded).expect("encoded output must decode back");
+    assert_eq!(decoded, s, "encode/decode roundtrip must preserve input");
+});


### PR DESCRIPTION
Closes #122

## Summary

- `fuzz/` — self-contained workspace (empty `[workspace]` table so the parent crate's wasm dev-deps don't leak in). Three libFuzzer targets:
  - `fuzz_normalize_path` — asserts idempotence and absoluteness preservation.
  - `fuzz_join_paths` — drives `(base, segment)` against arbitrary UTF-8, asserts no panic.
  - `fuzz_urlencoding_roundtrip` — asserts `decode(encode(s)) == s` for any UTF-8 input.
- `.github/workflows/fuzz.yml` — `schedule: cron "0 5 * * 1"` (weekly Monday 05:00 UTC) plus `workflow_dispatch`. Matrix over the three targets, each runs for five minutes (`-max_total_time=300`). On failure uploads the corpus and crash artefacts.
- `fuzz/README.md` documents layout, local commands, and the CI cadence.
- `Cargo.toml` `exclude` adds `fuzz/**` so `cargo publish` does not ship the fuzz harnesses to crates.io.

## Why fuzz on top of proptest

`tests/proptest_utils.rs` covers the same functions but with a regex-bounded input alphabet. libFuzzer is coverage-guided and finds inputs that walk newly-discovered code paths — including UTF-8 boundary cases and adversarial sequences that the proptest grammar would never explore. The harnesses are intentionally small (3–10 lines each); the invariants they assert are the same as the proptest properties, so a crash in fuzz is a real bug rather than a property mismatch.

## Local verification

- `cargo machete` — clean (fuzz subcrate is its own workspace; not analysed)
- `cargo +nightly udeps --all-targets --all-features` — clean (root crate)
- `actionlint .github/workflows/fuzz.yml` — clean
- `reuse lint` — 145/145 files SPDX-tagged
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] Weekly cron runs; matrix completes all three targets within 20 min
- [ ] On a regression that produces a panic, the workflow uploads `fuzz/corpus/<target>/` and `fuzz/artifacts/<target>/` for inspection
- [ ] `cargo publish --dry-run` does not include `fuzz/` (covered by `exclude` in `Cargo.toml`)