### PR TITLE
#137 ci: authenticate release-plz as a dedicated GitHub App

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,12 @@
 #   `release` runs after the release PR is merged — it tags the commit,
 #   publishes to crates.io, and creates the matching GitHub release.
 #
+# Authentication is via a dedicated GitHub App (see
+# `docs/RELEASE_PLZ_APP_SETUP.md`). Each job mints a short-lived
+# installation token at start via `actions/create-github-app-token` and
+# passes it as `GITHUB_TOKEN` to release-plz. This keeps the repo-wide
+# "Allow GitHub Actions to create and approve pull requests" flag off.
+#
 # See `release-plz.toml` for the per-package configuration and
 # `RELEASE.md` for the human-facing flow.
 
@@ -19,8 +25,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-plz-${{ github.ref }}
@@ -32,10 +37,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'RAprogramm' }}
     steps:
+      - name: Mint GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -45,7 +58,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   release-plz-pr:
@@ -54,11 +67,18 @@ jobs:
     if: ${{ github.repository_owner == 'RAprogramm' }}
     needs: release-plz-release
     steps:
+      - name: Mint GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -68,5 +88,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,8 +69,13 @@ release PR's merge commit lands.
 - `.github/workflows/release-plz.yml` — the two jobs. Concurrency is keyed on `release-plz-${{ github.ref }}` so two pushes never race a release PR update.
 
 The `CRATES_IO_TOKEN` repository secret is reused from the previous
-manual flow. `GITHUB_TOKEN` is the standard workflow token with
-`contents: write` + `pull-requests: write` granted in the workflow.
+manual flow. Pull-request operations authenticate as a dedicated
+GitHub App: the workflow mints a short-lived installation token via
+`actions/create-github-app-token` from `RELEASE_PLZ_APP_ID` +
+`RELEASE_PLZ_APP_PRIVATE_KEY` and hands it to `release-plz`. Setup is
+documented in [`docs/RELEASE_PLZ_APP_SETUP.md`](docs/RELEASE_PLZ_APP_SETUP.md) —
+the App scopes are exactly `Contents: read & write` and `Pull
+requests: read & write`, scoped to this single repository.
 
 ## What the maintainer still does
 

--- a/docs/RELEASE_PLZ_APP_SETUP.md
+++ b/docs/RELEASE_PLZ_APP_SETUP.md
@@ -1,0 +1,106 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# release-plz GitHub App setup
+
+`.github/workflows/release-plz.yml` authenticates as a dedicated
+GitHub App rather than as the default `GITHUB_TOKEN`. The App has
+exactly two permissions — `Contents: read & write` and `Pull
+requests: read & write` — and is installed on this single repository.
+At job start the workflow exchanges the App's ID + private key for a
+short-lived installation token via
+`actions/create-github-app-token@v2`. That token is then passed to
+`release-plz` as `GITHUB_TOKEN`.
+
+This is the one-time setup the maintainer runs before the workflow
+turns green.
+
+## Why an App rather than the default token
+
+The default `GITHUB_TOKEN` cannot open pull requests unless
+`Settings → Actions → General → Workflow permissions → Allow GitHub
+Actions to create and approve pull requests` is enabled. That flag is
+repo-wide and applies to *every* workflow. An App keeps the broad
+flag disabled while granting `release-plz` exactly the permissions it
+needs.
+
+A PAT would also work, but PATs expire and are tied to a person; the
+App identity is project-scoped and short-lived tokens never need to
+be rotated.
+
+## Steps
+
+### 1. Create the App
+
+Go to <https://github.com/settings/apps/new> (or
+`https://github.com/organizations/<org>/settings/apps/new` if the
+repository is org-owned).
+
+| Field | Value |
+|---|---|
+| GitHub App name | `release-plz-yew-nav-link` (or any unique name) |
+| Homepage URL | `https://github.com/RAprogramm/yew-nav-link` |
+| Webhook → Active | unchecked |
+| Permissions → Repository → Contents | Read and write |
+| Permissions → Repository → Pull requests | Read and write |
+| Subscribe to events | none |
+| Where can this GitHub App be installed? | Only on this account |
+
+Save. GitHub redirects to the App's settings page.
+
+### 2. Capture the App ID and a private key
+
+On the App settings page:
+
+1. Note the numeric **App ID** at the top.
+2. Scroll to **Private keys** → **Generate a private key**. A `.pem`
+   file downloads. Keep it; the next step uploads its contents to a
+   secret.
+
+### 3. Install the App on the repo
+
+On the App settings page → **Install App** → choose your account →
+**Only select repositories** → tick `yew-nav-link`. Confirm.
+
+### 4. Upload the two secrets
+
+Repository → **Settings → Secrets and variables → Actions → New
+repository secret**:
+
+| Secret name | Value |
+|---|---|
+| `RELEASE_PLZ_APP_ID` | the numeric App ID from step 2 |
+| `RELEASE_PLZ_APP_PRIVATE_KEY` | the full contents of the `.pem` from step 2, including the BEGIN/END lines |
+
+### 5. Trigger the workflow
+
+The next push to `main` triggers `Release-plz`. The workflow's `Mint
+GitHub App token` step exchanges the App ID + private key for an
+installation token, hands it to `release-plz`, and the release PR
+opens as `release-plz-yew-nav-link[bot]`.
+
+## Rotation
+
+GitHub App private keys do not expire. Rotate only on suspected
+compromise: regenerate the private key on the App settings page,
+update the `RELEASE_PLZ_APP_PRIVATE_KEY` secret, revoke the old key.
+Existing release-plz PRs continue to work; only future workflow runs
+mint tokens from the new key.
+
+## Removal
+
+To switch back to `GITHUB_TOKEN`: enable the repo-wide flag (Settings
+→ Actions → General → Workflow permissions), then revert the `Mint
+GitHub App token` step in `release-plz.yml` and delete the two
+secrets. The App can be uninstalled from the repo or deleted entirely.
+
+## References
+
+- [`release-plz.yml`](../.github/workflows/release-plz.yml) — the
+  workflow that consumes these secrets.
+- [`RELEASE.md`](../RELEASE.md) — the human-facing release flow.
+- [GitHub Apps docs — installation access tokens][gh-installation].
+
+[gh-installation]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app#authentication-as-a-github-app-installation


### PR DESCRIPTION
Closes #137

## Summary

- `.github/workflows/release-plz.yml`: each job now starts with a `Mint GitHub App token` step using `actions/create-github-app-token@v2`. The minted installation token is passed to `actions/checkout` (so subsequent pushes from the workflow are signed as the App) and to `release-plz` as `GITHUB_TOKEN`. The default `GITHUB_TOKEN` is no longer used by this workflow.
- `docs/RELEASE_PLZ_APP_SETUP.md` — new file: step-by-step App creation, install, secret upload, rotation policy, removal path.
- `RELEASE.md` "Configuration" section updated to describe the App identity and to point at the setup doc.

## What the maintainer needs to do before merging

This is the only PR in the session that has a manual prerequisite. Five minutes total, all in the GitHub UI:

1. <https://github.com/settings/apps/new> → create `release-plz-yew-nav-link` with permissions **Contents: r/w** and **Pull requests: r/w**, **Webhook → Active: unchecked**, install scope **Only on this account**.
2. Note the App ID. Generate a private key (`.pem` downloads).
3. Install the App on `RAprogramm/yew-nav-link` only.
4. Repo → Settings → Secrets → add `RELEASE_PLZ_APP_ID` (the number) and `RELEASE_PLZ_APP_PRIVATE_KEY` (the `.pem` contents).
5. Merge this PR. The next push to `main` triggers `Release-plz`; the App identity opens the release PR (release-plz already calculated next version is 0.10.1).

The `docs/RELEASE_PLZ_APP_SETUP.md` doc has the same steps with screenshots of each field's exact value.

## Why an App rather than enabling the repo-wide flag

The minimum-viable fix is to flip `Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests` on. That flag is **repo-wide**: every workflow in the repo gets the ability to open and approve PRs. A dedicated App:

- declares exactly `contents: write` and `pull_requests: write` and nothing else;
- emits a short-lived installation token (no rotation, no expiry surprises);
- shows up in the GitHub UI under its own identity, distinct from `github-actions[bot]`;
- keeps the repo-wide flag disabled, so no other workflow can be used to open or approve PRs.

For a release-bearing crate that wants the supply-chain narrative tight (KaiCode "static analysis", "code reviews", "releases / semantic versioning"), the App is the canonical professional answer.

## Local verification

- `actionlint .github/workflows/release-plz.yml` — clean
- `reuse lint` — 147/147 files SPDX-tagged
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] Maintainer completes the 5-step setup above
- [ ] `Release-plz` workflow succeeds on the next push to `main`
- [ ] Opened release PR carries the App identity (`release-plz-yew-nav-link[bot]`)
- [ ] Repo-wide "Allow GitHub Actions to create and approve pull requests" flag stays disabled