### PR TITLE
#137 ci: authenticate release-plz as a dedicated GitHub App

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,14 @@
 #   `release` runs after the release PR is merged — it tags the commit,
 #   publishes to crates.io, and creates the matching GitHub release.
 #
+# Authentication is via a dedicated GitHub App (see
+# `docs/RELEASE_PLZ_APP_SETUP.md`). The App identity is required, not
+# optional: PRs opened by `secrets.GITHUB_TOKEN` do not trigger
+# downstream workflows (the `CI` checks for the release PR, the
+# `Release attestations` workflow for the published release). Using
+# the App identity makes every release fully autonomous from a single
+# conventional commit on `main`.
+#
 # See `release-plz.toml` for the per-package configuration and
 # `RELEASE.md` for the human-facing flow.
 
@@ -19,8 +27,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-plz-${{ github.ref }}
@@ -32,10 +39,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'RAprogramm' }}
     steps:
+      - name: Mint GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -45,7 +60,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   release-plz-pr:
@@ -54,11 +69,18 @@ jobs:
     if: ${{ github.repository_owner == 'RAprogramm' }}
     needs: release-plz-release
     steps:
+      - name: Mint GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -68,5 +90,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,8 +69,17 @@ release PR's merge commit lands.
 - `.github/workflows/release-plz.yml` — the two jobs. Concurrency is keyed on `release-plz-${{ github.ref }}` so two pushes never race a release PR update.
 
 The `CRATES_IO_TOKEN` repository secret is reused from the previous
-manual flow. `GITHUB_TOKEN` is the standard workflow token with
-`contents: write` + `pull-requests: write` granted in the workflow.
+manual flow. Pull-request and release operations authenticate as a
+dedicated GitHub App: the workflow mints a short-lived installation
+token via `actions/create-github-app-token` from
+`RELEASE_PLZ_APP_ID` + `RELEASE_PLZ_APP_PRIVATE_KEY` and hands it to
+release-plz. Setup is documented in
+[`docs/RELEASE_PLZ_APP_SETUP.md`](docs/RELEASE_PLZ_APP_SETUP.md) — the App
+permissions are exactly `Contents: read & write` and `Pull requests:
+read & write`, scoped to this single repository. The App identity is
+required, not optional: PRs and releases created by the default
+`GITHUB_TOKEN` do not trigger downstream workflows, breaking the
+autonomous release loop.
 
 ## What the maintainer still does
 

--- a/docs/RELEASE_PLZ_APP_SETUP.md
+++ b/docs/RELEASE_PLZ_APP_SETUP.md
@@ -1,0 +1,134 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov-vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# release-plz GitHub App setup
+
+`.github/workflows/release-plz.yml` authenticates as a dedicated
+GitHub App rather than as the default `GITHUB_TOKEN`. The App has
+exactly two permissions — `Contents: read & write` and `Pull
+requests: read & write` — and is installed on this single repository.
+At job start the workflow exchanges the App's ID + private key for a
+short-lived installation token via
+`actions/create-github-app-token@v2`. That token is then passed to
+`release-plz` as `GITHUB_TOKEN`.
+
+This is the one-time setup the maintainer runs before the workflow
+turns green.
+
+## Why an App is required (not optional)
+
+The default `secrets.GITHUB_TOKEN` has two problems for release-plz:
+
+1. It cannot open pull requests unless the repo-wide
+   `Settings → Actions → General → Workflow permissions → Allow GitHub
+   Actions to create and approve pull requests` flag is enabled. That
+   flag is broad — it applies to *every* workflow in the repo.
+2. Even with the flag on, PRs and releases created with the default
+   token **do not trigger downstream workflows**. The `CI` workflow
+   does not run on the release PR; `Release attestations` does not
+   fire on the published release. Every release would require manual
+   close+reopen of the PR and manual `workflow_dispatch` for the
+   attestation workflow. That is not "automatic".
+
+The App identity is treated as an external actor: PRs and releases
+it creates do trigger downstream workflows. Setup is one-time; after
+that every release is end-to-end autonomous from a single
+conventional commit on `main`.
+
+A PAT would also work, but PATs expire and are tied to a person; the
+App identity is project-scoped and short-lived tokens never need to
+be rotated.
+
+## Steps
+
+### 1. Create the App
+
+Go to <https://github.com/settings/apps/new> (or
+`https://github.com/organizations/<org>/settings/apps/new` if the
+repository is org-owned).
+
+| Field | Value |
+|---|---|
+| GitHub App name | `release-plz-yew-nav-link` (or any unique name) |
+| Homepage URL | `https://github.com/RAprogramm/yew-nav-link` |
+| Webhook → Active | unchecked |
+| Permissions → Repository → Contents | Read and write |
+| Permissions → Repository → Pull requests | Read and write |
+| Subscribe to events | none |
+| Where can this GitHub App be installed? | Only on this account |
+
+Save. GitHub redirects to the App's settings page.
+
+### 2. Capture the App ID and a private key
+
+On the App settings page:
+
+1. Note the numeric **App ID** at the top.
+2. Scroll to **Private keys** → **Generate a private key**. A `.pem`
+   file downloads. Keep it; the next step uploads its contents to a
+   secret.
+
+### 3. Install the App on the repo
+
+On the App settings page → **Install App** → choose your account →
+**Only select repositories** → tick `yew-nav-link`. Confirm.
+
+### 4. Upload the two secrets
+
+Repository → **Settings → Secrets and variables → Actions → New
+repository secret**:
+
+| Secret name | Value |
+|---|---|
+| `RELEASE_PLZ_APP_ID` | the numeric App ID from step 2 |
+| `RELEASE_PLZ_APP_PRIVATE_KEY` | the full contents of the `.pem` from step 2, including the BEGIN/END lines |
+
+### 5. Disable the now-redundant repo-wide flag
+
+After the App is in place, the repo-wide flag enabled earlier
+becomes redundant. Tighten it back:
+
+```bash
+gh api repos/RAprogramm/yew-nav-link/actions/permissions/workflow \
+  -X PUT \
+  -F default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+```
+
+This step is optional but recommended; the App alone is sufficient.
+
+### 6. Trigger the workflow
+
+The next push to `main` triggers `Release-plz`. The workflow's `Mint
+GitHub App token` step exchanges the App ID + private key for an
+installation token, hands it to `release-plz`, and the release PR
+opens as `release-plz-yew-nav-link[bot]`. From here on every release
+is fully autonomous: open release PR → CI runs on it → squash-merge
+→ publish → `Release attestations` fires.
+
+## Rotation
+
+GitHub App private keys do not expire. Rotate only on suspected
+compromise: regenerate the private key on the App settings page,
+update the `RELEASE_PLZ_APP_PRIVATE_KEY` secret, revoke the old key.
+Existing release-plz PRs continue to work; only future workflow runs
+mint tokens from the new key.
+
+## Removal
+
+To switch back to `GITHUB_TOKEN`: enable the repo-wide flag (Settings
+→ Actions → General → Workflow permissions), then revert the `Mint
+GitHub App token` steps in `release-plz.yml` and delete the two
+secrets. The App can be uninstalled from the repo or deleted entirely.
+Note that the manual close+reopen-and-dispatch dance returns.
+
+## References
+
+- [`release-plz.yml`](../.github/workflows/release-plz.yml) — the
+  workflow that consumes these secrets.
+- [`RELEASE.md`](../RELEASE.md) — the human-facing release flow.
+- [GitHub Apps docs — installation access tokens][gh-installation].
+
+[gh-installation]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app#authentication-as-a-github-app-installation


### PR DESCRIPTION
Closes #137

## Why this is back (after #138 was closed)

Closing #138 in favor of just toggling `can_approve_pull_request_reviews=true` looked simpler, but the v0.10.1 release run proved it isn't a real fix:

- The release PR #139 opened by release-plz did **not** trigger CI. Required `CI Success` check stayed missing; merging required a manual close+reopen of the PR to retrigger the workflow.
- The GitHub Release v0.10.1 created by release-plz did **not** trigger `Release attestations`. SBOM + provenance were attached only after a manual `gh workflow run release-attestations.yml -f tag=v0.10.1`.

Both happen because PRs and releases authored by `secrets.GITHUB_TOKEN` are deliberately excluded from triggering downstream workflows. The checkbox unblocks PR creation but does nothing for trigger propagation. An App identity is the only structural fix; everything else is a manual workaround that breaks on every release.

## Summary

- `.github/workflows/release-plz.yml` — each job now mints an installation token via `actions/create-github-app-token@v2` from `RELEASE_PLZ_APP_ID` + `RELEASE_PLZ_APP_PRIVATE_KEY` secrets, then passes the token to `actions/checkout` and to release-plz as `GITHUB_TOKEN`. The default workflow token is no longer used here.
- `docs/RELEASE_PLZ_APP_SETUP.md` — step-by-step setup with the *why* explained: required not optional, App vs PAT vs default token trade-offs, rotation, removal path.
- `RELEASE.md` "Configuration" section rewritten to describe the App identity and to point at the setup doc.

## What the maintainer does once (then never again)

1. <https://github.com/settings/apps/new> → name `release-plz-yew-nav-link`, **Webhook → Active: unchecked**, permissions **Contents: r/w** + **Pull requests: r/w**, install scope **Only on this account**.
2. Note App ID. Generate private key (`.pem` downloads).
3. Install the App on `RAprogramm/yew-nav-link` only.
4. Repo Settings → Secrets → add `RELEASE_PLZ_APP_ID` (the number) and `RELEASE_PLZ_APP_PRIVATE_KEY` (the full `.pem`).
5. Merge this PR.
6. Optional, after step 5 confirms green: tighten the workflow_permissions toggle back via
   `gh api repos/RAprogramm/yew-nav-link/actions/permissions/workflow -X PUT -F default_workflow_permissions=read -F can_approve_pull_request_reviews=false`.

After step 5 the loop is autonomous: conventional commit lands on `main` → release PR opens (CI runs on it automatically) → squash-merge → publish + tag + GitHub Release → `Release attestations` fires automatically and attaches SBOM + SLSA provenance. No reruns, no dispatches.

## Local verification

- `actionlint .github/workflows/release-plz.yml` — clean
- `reuse lint` — 147/147 files SPDX-tagged
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint all green

## Test plan

- [ ] Maintainer completes the 5-step setup above
- [ ] Merge this PR
- [ ] Next conventional commit on `main` triggers Release-plz, opens a release PR, CI runs on it without intervention
- [ ] Merging that release PR publishes to crates.io and fires Release attestations automatically