### PR TITLE
#146 ci: tighten top-level workflow permissions to contents: read

### DIFF
--- a/.github/workflows/changelog-refresh.yml
+++ b/.github/workflows/changelog-refresh.yml
@@ -13,8 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: changelog-refresh
@@ -25,6 +24,9 @@ jobs:
     name: Refresh
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,7 @@ on:
         type: boolean
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
-  attestations: write
-  issues: read
-  discussions: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/release-attestations.yml
+++ b/.github/workflows/release-attestations.yml
@@ -19,9 +19,7 @@ on:
         type: string
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 concurrency:
   group: release-attestations-${{ github.event.release.tag_name || inputs.tag }}
@@ -32,6 +30,10 @@ jobs:
     name: Generate SBOM and provenance
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout tagged commit
         uses: actions/checkout@v6


### PR DESCRIPTION
Closes #146

## Summary

Three workflows had `contents: write` (and other writes) at the top level. OSSF Scorecard's `TokenPermissionsID` rule flags this — best practice is `contents: read` at the top, with writes scoped to the specific jobs that need them.

- **`ci.yml`** — top-level had `contents/pull-requests/id-token/attestations: write` + `issues: read, discussions: write`. None of the current CI jobs write to the repo (the old manual `release` job that needed them was removed in #118). Top-level now just `contents: read`.
- **`changelog-refresh.yml`** — top-level had `contents/pull-requests: write` for the `peter-evans/create-pull-request` step. Moved to the `refresh` job's `permissions:` block.
- **`release-attestations.yml`** — top-level had `contents/id-token/attestations: write` for `actions/attest-build-provenance` + `gh release upload`. Moved to the `attest` job's `permissions:` block.

`codeql.yml`, `scorecard.yml`, `fuzz.yml`, `mutants.yml`, `release-plz.yml` already had read-only top-level. `pages.yml` had `contents: read` at top with `pages/id-token: write` (those are scoped GitHub-feature permissions, not flagged by Scorecard).

## Local verification

- `actionlint .github/workflows/*.yml` — clean
- `reuse lint` — green
- `.hooks/pre-commit` — fmt, clippy, deny, audit, actionlint green

## Test plan

- [ ] CI on this PR stays green — none of the workflows actually needed the broader top-level permissions
- [ ] Scorecard's 3 `TokenPermissionsID` alerts close on the next scan