### PR TITLE
#155 ci: treat cargo-mutants surviving mutants as report, not failure

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -54,6 +54,7 @@ jobs:
           tool: cargo-mutants
 
       - name: Run cargo-mutants
+        continue-on-error: true
         run: cargo mutants --no-shuffle --timeout-multiplier 2 --output mutants.out
 
       - name: Append mutants summary to workflow output


### PR DESCRIPTION
Closes #155

`continue-on-error: true` on the Run cargo-mutants step. The step still produces `mutants.out/outcomes.json` and the summary step runs after — only the workflow's own success/failure marker changes.

Today's first run reported `214 mutants tested: 131 caught, 47 missed, 36 unviable`. The missed set is in wasm-only hooks (`use_is_exact_active`, `use_breadcrumbs`, etc.) whose tests run under `wasm-pack` and don't cover the native mutation matrix. Useful signal, not a merge blocker.

mutants is a **map**, not a **gate**. semver-checks and public-api remain gates; mutants joins coverage as informational.