### PR TITLE
#160 ci normalize project commit format in cliff.toml so CHANGELOG body populates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,11 @@ git checkout -b 123
 ### 3. Commit format
 
 ```bash
-git commit -m "#123 feat: add custom class support"
+git commit -m "#123 feat add custom class support"
 ```
+
+Format is `#<issue> <type> <description>` — no colon after the type, no
+`(scope)`. Breaking changes carry a `!` on the type (`feat!`, `refactor!`).
 
 | Type | Use for | Triggers in CHANGELOG |
 |---|---|---|
@@ -99,7 +102,9 @@ git commit -m "#123 feat: add custom class support"
 | `test` | Test additions or modifications | no |
 | `chore` | Maintenance, dependency bumps, tooling | no |
 
-`git-cliff` reads these prefixes (`cliff.toml`).
+`git-cliff` reads these prefixes (`cliff.toml`), normalising the
+`#<N> <type> <desc>` form into a conventional-commit subject for the
+CHANGELOG.
 
 ### 4. Open a pull request
 
@@ -172,8 +177,8 @@ Releases are fully autonomous from a contributor's perspective. The
 maintainer does **not** edit `Cargo.toml` or `CHANGELOG.md` by hand —
 [release-plz](https://release-plz.dev) does it. The loop:
 
-1. Land any conventional commit on `main` (`feat:`, `fix:`, `docs:`,
-   `refactor:`, `ci:`, `deps:` — `test:` and `chore:` are skipped).
+1. Land any typed commit on `main` (`feat`, `fix`, `docs`, `refactor`,
+   `ci`, `deps` — `test` and `chore` are skipped).
 2. `Release-plz` workflow opens (or updates) a single release PR titled
    `chore: release vX.Y.Z`. The version bump and `CHANGELOG.md` section
    are derived from the conventional commits since the last tag.

--- a/cliff.toml
+++ b/cliff.toml
@@ -21,6 +21,7 @@ filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
   { pattern = '\(#(\d+)\)', replace = "([#${1}](https://github.com/RAprogramm/yew-nav-link/issues/${1}))" },
+  { pattern = '^#\d+\s+(feat|fix|refactor|docs|ci|chore|test|deps|revert)(!)?:?\s+', replace = "${1}${2}: " },
 ]
 commit_parsers = [
   { author = "dependabot", group = "Dependencies" },
@@ -29,6 +30,7 @@ commit_parsers = [
   { message = "^refactor", group = "Refactoring" },
   { message = "^docs", group = "Documentation" },
   { message = "^ci", group = "CI" },
+  { message = "^revert", group = "Reverts" },
   { message = "^deps|^chore\\(deps\\)", group = "Dependencies" },
   { message = "^chore", skip = true },
   { message = "^test", skip = true },

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -47,15 +47,16 @@ clean up before pushing if needed.
 
 ## 3. Commit format
 
-Every commit message starts with the issue reference and a conventional
-commit prefix:
+Every commit message starts with the issue reference and a type prefix:
 
 ```
-#<issue> <type>: <description>
+#<issue> <type> <description>
 ```
 
-The prefixes feed `cliff.toml` and decide which CHANGELOG section the
-commit lands in:
+No colon after the type, no `(scope)`. `cliff.toml` rewrites this form
+into a conventional-commit subject (`<type>: <description>`) before
+git-cliff classifies it, so the prefixes still decide which CHANGELOG
+section the commit lands in:
 
 | Prefix | CHANGELOG section | Triggers minor/patch bump under release-plz |
 |---|---|---|
@@ -68,7 +69,7 @@ commit lands in:
 | `test` | (skipped) | none |
 | `chore` | (skipped) | none |
 
-Breaking changes carry a `!` after the type (`feat!:`, `refactor!:`) and
+Breaking changes carry a `!` after the type (`feat!`, `refactor!`) and
 trigger a major bump.
 
 ## 4. Merge style
@@ -118,7 +119,7 @@ git push -u origin <new-issue>
 gh pr create --title "<new-issue>" --body "Closes #<new-issue>"
 ```
 
-The revert commit follows the same `#<issue> revert: <description>` form,
+The revert commit follows the same `#<issue> revert <description>` form,
 and the new issue documents *why* the original change was rolled back.
 
 ## 7. Releases


### PR DESCRIPTION
Closes #160.

## Summary

The project commit convention is \`#<N> <type> <desc>\` (no colon, no scope) per the maintainer's workflow rules, but \`cliff.toml\` set \`conventional_commits = true\` + \`filter_unconventional = true\`, so git-cliff's conventional parser rejected every typed commit as unconventional and filtered it out. CHANGELOG entries for 0.10.2/0.10.3 ended up empty and release-plz PR #159 ships with an empty \`<details>\` body. The only reason 0.10.1 was non-empty is that the dependabot author parser bypasses message-format matching.

- \`cliff.toml\`: added a second \`commit_preprocessors\` entry that rewrites \`^#\d+\s+(feat|fix|refactor|docs|ci|chore|test|deps|revert)(!)?:?\s+\` into \`<type>: \` so the conventional parser succeeds. Optional \`:\` accommodates the historical mixed-format commits in the log. Added a \`Reverts\` group for completeness — the docs allow revert commits but the parsers had no slot for them.
- \`CONTRIBUTING.md\` + \`docs/BRANCHING.md\`: documented commit format now reads \`#<issue> <type> <description>\` (no colon). Breaking-change marker shown as \`feat!\` / \`refactor!\` instead of \`feat!:\` / \`refactor!:\`. Revert form aligned the same way.

Verified locally with \`git-cliff --tag v0.10.4 v0.10.3..HEAD\`:

\`\`\`
## [0.10.4] - 2026-05-12

### Documentation

- refresh ROADMAP after 0.10.x release ([#158](...))
\`\`\`

Backfilling for older ranges (\`v0.10.0..v0.10.3\`) likewise populates CI/Documentation/Refactoring groups that were previously empty.

## Test plan

- [x] \`git-cliff --tag v0.10.4 v0.10.3..HEAD\` produces a non-empty Documentation section
- [x] Pre-commit hooks pass (fmt, clippy, deny, audit, actionlint)
- [ ] CI green
- [ ] Once merged, release-plz refreshes PR #159 with a non-empty Changelog body on its next run