### PR TITLE
#162 ci mirror cliff.toml commit preprocessor into release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -40,12 +40,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 """
+commit_preprocessors = [
+    { pattern = '\(#(\d+)\)', replace = "([#${1}](https://github.com/RAprogramm/yew-nav-link/issues/${1}))" },
+    { pattern = '^#\d+\s+(feat|fix|refactor|docs|ci|chore|test|deps|revert)(!)?:?\s+', replace = "${1}${2}: " },
+]
 commit_parsers = [
     { message = "^feat", group = "Features" },
     { message = "^fix", group = "Bug Fixes" },
     { message = "^refactor", group = "Refactoring" },
     { message = "^docs", group = "Documentation" },
     { message = "^ci", group = "CI" },
+    { message = "^revert", group = "Reverts" },
     { message = "^deps|^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore", skip = true },
     { message = "^test", skip = true },


### PR DESCRIPTION
Closes #162. Follow-up to #160/#161.

## Summary

#161 fixed \`cliff.toml\` so git-cliff understands the project's \`#<N> <type> <desc>\` commit format. But release-plz keeps its own \`[changelog]\` block inside \`release-plz.toml\` and does **not** read \`cliff.toml\`. So PR #159 (release v0.10.4) still produced an empty Changelog body even after #161 merged.

This change mirrors the \`commit_preprocessors\` array (PR-ref linkification + project-format → conventional rewrite) and adds the \`Reverts\` parser into \`release-plz.toml\`'s \`[changelog]\` block. The two configs now stay aligned by hand — a comment in \`release-plz.toml\` already noted this mirroring intent.

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI green
- [ ] After merge, release-plz re-runs on the push and updates PR #159 with a populated \`<details>\` Changelog block