### PR TITLE
#164 ci pass GITHUB_TOKEN to git-cliff in changelog-refresh workflow

### DIFF
--- a/.github/workflows/changelog-refresh.yml
+++ b/.github/workflows/changelog-refresh.yml
@@ -39,6 +39,8 @@ jobs:
           tool: git-cliff
 
       - name: Regenerate [Unreleased] in CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           git-cliff --unreleased > /tmp/unreleased.md


### PR DESCRIPTION
Closes #164.

## Summary

Last scheduled \`Changelog refresh\` run (2026-05-11 07:24 UTC) panicked with HTTP 401 from \`api.github.com/repos/.../pulls?state=closed\`. \`cliff.toml\` declares \`[remote.github] token = \"\"\`, so git-cliff falls back to env vars; the workflow step exported neither \`GH_TOKEN\` nor \`GITHUB_TOKEN\`. Anonymous PR-list queries return 401.

Exporting \`GITHUB_TOKEN\` from the default \`secrets.GITHUB_TOKEN\` to the \`Regenerate [Unreleased]\` step lets git-cliff authenticate. The job's existing top-level \`permissions: pull-requests: write\` already covers the scope needed for the read-only \`/pulls\` query.

## Local verification

\`\`\`
$ actionlint .github/workflows/changelog-refresh.yml
(no output)
$ GITHUB_TOKEN=\$(gh auth token) git-cliff --unreleased
# Changelog

## [Unreleased]
\`\`\`

(no commits since v0.10.4 → workflow will take the \"No unreleased commits\" early-exit branch, not open a PR.)

## Test plan

- [x] actionlint locally
- [x] \`git-cliff --unreleased\` succeeds locally with token
- [ ] CI green
- [ ] After merge: \`gh workflow run changelog-refresh.yml\` exits 0 with the early-exit branch