### PR TITLE
#168 ci pin cargo-fuzz target to x86_64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -54,7 +54,7 @@ jobs:
           tool: cargo-fuzz
 
       - name: Run ${{ matrix.target }}
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=300
+        run: cargo fuzz run --target x86_64-unknown-linux-gnu ${{ matrix.target }} -- -max_total_time=300
         working-directory: fuzz
 
       - name: Upload corpus and artifacts on failure

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -24,13 +24,17 @@ input generator.
 ```bash
 cargo install --locked cargo-fuzz
 cd fuzz
-cargo +nightly fuzz run fuzz_normalize_path -- -max_total_time=60
-cargo +nightly fuzz run fuzz_join_paths -- -max_total_time=60
-cargo +nightly fuzz run fuzz_urlencoding_roundtrip -- -max_total_time=60
+cargo +nightly fuzz run --target x86_64-unknown-linux-gnu fuzz_normalize_path -- -max_total_time=60
+cargo +nightly fuzz run --target x86_64-unknown-linux-gnu fuzz_join_paths -- -max_total_time=60
+cargo +nightly fuzz run --target x86_64-unknown-linux-gnu fuzz_urlencoding_roundtrip -- -max_total_time=60
 ```
 
 `cargo fuzz` requires a nightly toolchain — the macro it expands to
-needs unstable `#[no_main]` instrumentation hooks.
+needs unstable `#[no_main]` instrumentation hooks. The explicit
+`--target x86_64-unknown-linux-gnu` is required on hosts where
+cargo-fuzz would otherwise pick `x86_64-unknown-linux-musl`; musl's
+static libc is incompatible with AddressSanitizer's dynamic-libc
+instrumentation.
 
 ## Layout
 


### PR DESCRIPTION
Closes #168.

## Summary

First manual dispatch of \`.github/workflows/fuzz.yml\` (run 25769641220) failed all three targets with:

\`\`\`
error: sanitizer is incompatible with statically linked libc,
       disable it using \`-C target-feature=-crt-static\`
error[E0463]: can't find crate for \`core\`
\`\`\`

The verbose cargo invocation in the error preamble shows cargo-fuzz selected \`--target x86_64-unknown-linux-musl\` on the ubuntu-latest runner; musl statically links libc, AddressSanitizer needs dynamic libc, rustc bails.

Pin \`--target x86_64-unknown-linux-gnu\` in the workflow's \`cargo fuzz run\` invocation and mirror the same flag in \`fuzz/README.md\`'s local recipe so contributors don't hit the same wall on hosts that default to musl.

## Verification

- Local (Arch glibc): \`cargo +nightly fuzz run --target x86_64-unknown-linux-gnu fuzz_normalize_path -- -max_total_time=5\` → \`Done 1579598 runs in 6 second(s)\`, no errors.
- CI (workflow_dispatch on branch \`168\`, run [25770046370](https://github.com/RAprogramm/yew-nav-link/actions/runs/25770046370)): all three matrix jobs (\`fuzz_normalize_path\`, \`fuzz_join_paths\`, \`fuzz_urlencoding_roundtrip\`) **success** after running the full 5-minute budget per target.

## Test plan

- [x] actionlint locally
- [x] cargo-fuzz with explicit gnu target works locally
- [x] workflow_dispatch on branch 168 → all 3 targets pass
- [ ] PR CI green