### PR TITLE
#177 chore: refresh stale yew-nav-link version in example lockfile

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.9.3"
+version = "0.10.6"
 dependencies = [
  "yew",
  "yew-router",


### PR DESCRIPTION
Closes #177

The example lockfile recorded path-dependency `yew-nav-link` at 0.9.3 while the crate is at 0.10.6, so every `trunk build` left a dirty working tree. Regenerated by trunk during the #175 maintenance pass; committed here separately to keep main clean.