### PR TITLE
#179 ci: parse squash-merge commit bodies line by line in git-cliff

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -18,8 +18,9 @@ trim = true
 [git]
 conventional_commits = true
 filter_unconventional = true
-split_commits = false
+split_commits = true
 commit_preprocessors = [
+  { pattern = '^\* ', replace = "" },
   { pattern = '\(#(\d+)\)', replace = "([#${1}](https://github.com/RAprogramm/yew-nav-link/issues/${1}))" },
   { pattern = '^#\d+\s+(feat|fix|refactor|docs|ci|chore|test|deps|revert)(!)?:?\s+', replace = "${1}${2}: " },
 ]
@@ -34,7 +35,6 @@ commit_parsers = [
   { message = "^deps|^chore\\(deps\\)", group = "Dependencies" },
   { message = "^chore", skip = true },
   { message = "^test", skip = true },
-  { body = ".*", group = "Other" },
 ]
 filter_commits = false
 tag_pattern = "v[0-9].*"


### PR DESCRIPTION
Closes #179

The #175 maintenance pass was squash-merged with a bare `175` PR title, so git-cliff (with `filter_unconventional = true` and the `#N type: description` preprocessor) dropped the entire pass from the regenerated Unreleased section, even though the squash body lists every conventional commit message.

- `split_commits = true`: squash-commit bodies are parsed line by line, recovering per-commit changelog entries.
- New preprocessor strips the `* ` bullet prefix GitHub puts before each message in squash bodies.
- The `{ body = ".*", group = "Other" }` catch-all is removed: with line splitting it would collect noise (bare squash headlines, Co-authored-by trailers), contradicting `filter_unconventional`.

Verified locally with git-cliff 2.13.1: Unreleased now lists all 10 non-chore entries from the #175 pass grouped under Bug Fixes / Refactoring / Documentation / CI, with no noise entries; the released 0.10.5 section renders unchanged.

`release-plz.toml` is intentionally untouched — release-plz does not support `split_commits`, so complete release notes still rely on descriptive `#N type: description` PR titles (repo convention).