### PR TITLE
#182 ci: revert split_commits, dependabot squash bodies flood the changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -18,9 +18,8 @@ trim = true
 [git]
 conventional_commits = true
 filter_unconventional = true
-split_commits = true
+split_commits = false
 commit_preprocessors = [
-  { pattern = '^\* ', replace = "" },
   { pattern = '\(#(\d+)\)', replace = "([#${1}](https://github.com/RAprogramm/yew-nav-link/issues/${1}))" },
   { pattern = '^#\d+\s+(feat|fix|refactor|docs|ci|chore|test|deps|revert)(!)?:?\s+', replace = "${1}${2}: " },
 ]
@@ -35,6 +34,7 @@ commit_parsers = [
   { message = "^deps|^chore\\(deps\\)", group = "Dependencies" },
   { message = "^chore", skip = true },
   { message = "^test", skip = true },
+  { body = ".*", group = "Other" },
 ]
 filter_commits = false
 tag_pattern = "v[0-9].*"


### PR DESCRIPTION
Closes #182

Reverts the `[git]` section of cliff.toml to its pre-#181 state. `split_commits = true` was verified against a stale local main: on the real main, dependabot squash bodies (large PR descriptions) get split into dozens of lines, each matched by the `author = dependabot` parser, flooding the regenerated Unreleased section with duplicate entries.

The #175 entries this was meant to recover will be curated by hand in the release PR changelog instead. Complete release notes remain guaranteed by descriptive `#N type: description` PR titles.