### PR TITLE
#184 ci: strip git-cliff header when refreshing Unreleased changelog

### DIFF
--- a/.github/workflows/changelog-refresh.yml
+++ b/.github/workflows/changelog-refresh.yml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git-cliff --unreleased > /tmp/unreleased.md
+          git-cliff --unreleased --strip header > /tmp/unreleased.md
 
           if [ ! -s /tmp/unreleased.md ]; then
             echo "git-cliff produced no output; nothing to refresh."
@@ -58,8 +58,9 @@ jobs:
           changelog_path = pathlib.Path("CHANGELOG.md")
           unreleased = pathlib.Path("/tmp/unreleased.md").read_text().strip()
 
-          # If git-cliff yielded nothing more than its header, no commits
-          # have landed since the latest tag. Leave CHANGELOG.md alone.
+          # If git-cliff yielded nothing more than the section heading, no
+          # commits have landed since the latest tag. Leave CHANGELOG.md
+          # alone.
           stripped = unreleased.lower().replace(" ", "")
           if stripped in ("##[unreleased]", ""):
               print("No unreleased commits since the last tag.")
@@ -81,7 +82,7 @@ jobs:
               )
               sys.exit(1)
 
-          updated = pattern.sub(unreleased + "\n", changelog)
+          updated = pattern.sub(lambda _: unreleased + "\n", changelog)
 
           if updated == changelog:
               print("CHANGELOG.md already in sync.")


### PR DESCRIPTION
Closes #184

- `git-cliff --unreleased --strip header`: the refresh step was splicing the full git-cliff output — including its `# Changelog` header template — into the middle of CHANGELOG.md, prepending a duplicate heading on every refresh (visible in the PR #166 diff). It also made the no-commits guard unreachable, since the output always contained more than the bare section heading.
- `pattern.sub` now takes a callable so backslashes in commit messages can never be misinterpreted as regex group references.