### PR TITLE
#186 ci: assert Lighthouse thresholds against the median of three runs

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -3,7 +3,7 @@
         "collect": {
             "staticDistDir": "example/dist",
             "url": ["http://localhost/index.html"],
-            "numberOfRuns": 1,
+            "numberOfRuns": 3,
             "settings": {
                 "preset": "desktop",
                 "skipAudits": ["uses-http2"]


### PR DESCRIPTION
Closes #186

`numberOfRuns: 1` asserted the 0.85 performance minScore against a single sample on a shared runner: the identical demo build passed five CI runs today, then scored 0.79 and 0.82 twice in a row on the release PR, blocking it on rerun roulette. With three collected runs, lhci asserts against the median, absorbing runner variance without loosening the threshold.