### PR TITLE
#196 docs: update ARCHITECTURE.md layout after mod.rs rename

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,8 +14,9 @@ This is a design rationale, not a tutorial. For the *what*, read the
 src/
 ├── lib.rs            Public API and re-exports. The crate root re-exports
 │                     every type a typical consumer will reach for.
-├── active_link/      The NavLink<R> component, the Match enum, and the
-│   ├── mod.rs        per-render utility that decides the active state.
+├── active_link.rs    Module root for the NavLink<R> component: the Match
+│                     enum and re-exports of the submodules below.
+├── active_link/
 │   ├── nav_link.rs
 │   ├── props.rs
 │   ├── mode.rs
@@ -139,7 +140,7 @@ props.
 ```text
 tests/                                 # integration tests, Yew-aware
 benches/                               # criterion benchmarks (path utils)
-src/**/mod.rs (#[cfg(test)] modules)   # unit tests, focused per module
+src/**/*.rs (#[cfg(test)] modules)     # unit tests, focused per module
 ```
 
 Integration tests live in `tests/` so they run against the public API


### PR DESCRIPTION
Closes #196.

Follow-up to #194. Updates `docs/ARCHITECTURE.md` to the edition-2024 module layout:

- §1 crate-layout tree: `active_link/mod.rs` replaced with `active_link.rs` (module root) alongside the `active_link/` submodule directory.
- §6 test layout: `src/**/mod.rs` -> `src/**/*.rs`.

No `mod.rs` reference remains in `README.md` or `docs/`.