### PR TITLE
#206 docs: drop REQUIREMENTS reference to removed no_std CI job

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -132,7 +132,7 @@ escaping the root.
 | Edition | 2024 |
 | Yew | 0.23+ |
 | yew-router | 0.20+ |
-| `no_std` | **Not supported.** The Yew runtime requires `std`; this is a deliberate non-goal documented in CI's `no_std` job. |
+| `no_std` | **Not supported.** The Yew runtime requires `std` (allocations, `Rc`, threading primitives behind WASM); this is a deliberate non-goal. |
 | Browser support | Whatever Yew CSR + `wasm32-unknown-unknown` supports |
 
 ### 2.2 Versioning


### PR DESCRIPTION
Closes #206.

Line 135 described the `no_std` non-goal as "documented in CI's `no_std` job", but that job was removed in #199. Rewords it to state the non-goal directly (Yew requires `std`), with no reference to a non-existent job.