### PR TITLE
#211 chore: drop copyright years from license and SPDX headers

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 # cargo-mutants drives mutation testing for `yew-nav-link`. The defaults

--- a/.github/workflows/changelog-refresh.yml
+++ b/.github/workflows/changelog-refresh.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 name: Changelog refresh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 name: CodeQL

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 # Weekly coverage-guided fuzzing for the path / URL helpers. Each

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 # Mutation testing is the strongest available evidence that line/branch

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 name: Pages

--- a/.github/workflows/release-attestations.yml
+++ b/.github/workflows/release-attestations.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 # On every published GitHub release, generate a CycloneDX SBOM and a

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 # Two-mode release automation driven by release-plz:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 name: Scorecard

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 RAprogramm
+Copyright (c) RAprogramm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,5 +6,5 @@ SPDX-PackageDownloadLocation = "https://github.com/RAprogramm/yew-nav-link"
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>"
+SPDX-FileCopyrightText = "RAprogramm <andrey.rozanov.vl@gmail.com>"
 SPDX-License-Identifier = "MIT"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use std::hint::black_box;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/RELEASE_PLZ_APP_SETUP.md
+++ b/docs/RELEASE_PLZ_APP_SETUP.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/adr/0001-static-str-classes.md
+++ b/docs/adr/0001-static-str-classes.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/adr/0002-drop-macros-feature.md
+++ b/docs/adr/0002-drop-macros-feature.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/adr/0003-non-exhaustive-nav-error.md
+++ b/docs/adr/0003-non-exhaustive-nav-error.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/adr/0004-manual-anchor-over-yew-router-link.md
+++ b/docs/adr/0004-manual-anchor-over-yew-router-link.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/adr/0005-active-state-via-aria-current.md
+++ b/docs/adr/0005-active-state-via-aria-current.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" width="900" height="500" role="img" aria-labelledby="title desc" font-family="'Segoe UI', Helvetica, Arial, sans-serif">

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 [book]

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/example/e2e/README.md
+++ b/example/e2e/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/example/e2e/playwright.config.ts
+++ b/example/e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 import { defineConfig, devices } from '@playwright/test';

--- a/example/e2e/tests/breadcrumbs.spec.ts
+++ b/example/e2e/tests/breadcrumbs.spec.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 import { test, expect } from '@playwright/test';

--- a/example/e2e/tests/dropdown.spec.ts
+++ b/example/e2e/tests/dropdown.spec.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 import { test, expect } from '@playwright/test';

--- a/example/e2e/tests/navigation.spec.ts
+++ b/example/e2e/tests/navigation.spec.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 import { test, expect } from '@playwright/test';

--- a/example/e2e/tests/pagination.spec.ts
+++ b/example/e2e/tests/pagination.spec.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 import { test, expect } from '@playwright/test';

--- a/example/index.html
+++ b/example/index.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 <!DOCTYPE html>

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use std::rc::Rc;

--- a/example/styles/_a11y.scss
+++ b/example/styles/_a11y.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 // Accessibility scaffolding shared by every page:

--- a/example/styles/_components.scss
+++ b/example/styles/_components.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 // ─────────────────────────────────────────────────────────────────

--- a/example/styles/_dark.scss
+++ b/example/styles/_dark.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 @media (prefers-color-scheme: dark) {

--- a/example/styles/_layout.scss
+++ b/example/styles/_layout.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 .app-shell {

--- a/example/styles/_reset.scss
+++ b/example/styles/_reset.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 *,

--- a/example/styles/_tokens.scss
+++ b/example/styles/_tokens.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 :root {

--- a/example/styles/main.scss
+++ b/example/styles/main.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 // Order matters: tokens first (define vars), reset (uses vars), then

--- a/example/trunk.toml
+++ b/example/trunk.toml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 [build]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 [package]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/fuzz/fuzz_targets/fuzz_join_paths.rs
+++ b/fuzz/fuzz_targets/fuzz_join_paths.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![no_main]

--- a/fuzz/fuzz_targets/fuzz_normalize_path.rs
+++ b/fuzz/fuzz_targets/fuzz_normalize_path.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![no_main]

--- a/fuzz/fuzz_targets/fuzz_urlencoding_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_urlencoding_roundtrip.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![no_main]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 # SPDX-License-Identifier: MIT
 
 # release-plz drives the release cadence for `yew-nav-link`:

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
-# SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 #
 # Syncs version and MSRV references in docs from Cargo.toml, the single
 # source of truth. Run from the repository root:

--- a/src/active_link.rs
+++ b/src/active_link.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 pub mod mode;

--- a/src/active_link/mode.rs
+++ b/src/active_link/mode.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Active-state matching strategy.

--- a/src/active_link/nav_link.rs
+++ b/src/active_link/nav_link.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! The [`NavLink`] component and the [`nav_link`] function-syntax helper.

--- a/src/active_link/props.rs
+++ b/src/active_link/props.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Type-checked properties for [`crate::NavLink`].

--- a/src/active_link/utils.rs
+++ b/src/active_link/utils.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Helpers shared between [`crate::NavLink`] and its callers: segment-wise

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # Attribute Builders

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Navigation UI components.

--- a/src/components/badge.rs
+++ b/src/components/badge.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavBadge`

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavDropdown`

--- a/src/components/header.rs
+++ b/src/components/header.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavHeader`

--- a/src/components/icon.rs
+++ b/src/components/icon.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavIcon`

--- a/src/components/page_item.rs
+++ b/src/components/page_item.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `PageItem`

--- a/src/components/page_link.rs
+++ b/src/components/page_link.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `PageLink`

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # Pagination

--- a/src/components/pagination_page.rs
+++ b/src/components/pagination_page.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `Pagination Page Generation`

--- a/src/components/tab_item.rs
+++ b/src/components/tab_item.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavTab`

--- a/src/components/tab_panel.rs
+++ b/src/components/tab_panel.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavTabPanel`

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavTabs`

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavText`

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # NavError

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Reactive hooks for navigation state.

--- a/src/hooks/navigation.rs
+++ b/src/hooks/navigation.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 pub mod query_params;

--- a/src/hooks/navigation/query_params.rs
+++ b/src/hooks/navigation/query_params.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Query parameter hook.

--- a/src/hooks/navigation/use_navigation.rs
+++ b/src/hooks/navigation/use_navigation.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Programmatic navigation built on top of yew-router's `Navigator`.

--- a/src/hooks/route_info.rs
+++ b/src/hooks/route_info.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 pub mod active;

--- a/src/hooks/route_info/active.rs
+++ b/src/hooks/route_info/active.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use yew::prelude::*;

--- a/src/hooks/route_info/breadcrumbs.rs
+++ b/src/hooks/route_info/breadcrumbs.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use std::rc::Rc;

--- a/src/hooks/route_info/info.rs
+++ b/src/hooks/route_info/info.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use yew::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![deny(missing_docs)]

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Core navigation primitives.

--- a/src/nav/divider.rs
+++ b/src/nav/divider.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavDivider`

--- a/src/nav/item.rs
+++ b/src/nav/item.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavItem`

--- a/src/nav/list.rs
+++ b/src/nav/list.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # `NavList`

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Utility functions and helpers.

--- a/src/utils/keyboard.rs
+++ b/src/utils/keyboard.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Keyboard navigation utilities.

--- a/src/utils/keyboard/config.rs
+++ b/src/utils/keyboard/config.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Keyboard navigation configuration.

--- a/src/utils/keyboard/direction.rs
+++ b/src/utils/keyboard/direction.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Keyboard direction enum.

--- a/src/utils/keyboard/handlers.rs
+++ b/src/utils/keyboard/handlers.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Keyboard navigation handlers.

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! # Path Utilities

--- a/src/utils/url.rs
+++ b/src/utils/url.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! URL parsing utilities.

--- a/src/utils/url/codec.rs
+++ b/src/utils/url/codec.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! URL encoding/decoding utilities.

--- a/src/utils/url/parts.rs
+++ b/src/utils/url/parts.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! URL parts parsing.

--- a/src/utils/url/query.rs
+++ b/src/utils/url/query.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Query parameters utilities.

--- a/tests/attrs_test.rs
+++ b/tests/attrs_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![cfg(all(test, not(target_arch = "wasm32")))]

--- a/tests/components_test.rs
+++ b/tests/components_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Integration tests for components module.

--- a/tests/dropdown_test.rs
+++ b/tests/dropdown_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![cfg(all(test, not(target_arch = "wasm32")))]

--- a/tests/errors_test.rs
+++ b/tests/errors_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![cfg(all(test, not(target_arch = "wasm32")))]

--- a/tests/hooks_route_test.rs
+++ b/tests/hooks_route_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![cfg(all(test, not(target_arch = "wasm32")))]

--- a/tests/keyboard_test.rs
+++ b/tests/keyboard_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Keyboard navigation tests.

--- a/tests/nav_item_test.rs
+++ b/tests/nav_item_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Integration tests for nav components.

--- a/tests/nav_list_test.rs
+++ b/tests/nav_list_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Integration tests for nav module.

--- a/tests/pagination_test.rs
+++ b/tests/pagination_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![cfg(all(test, not(target_arch = "wasm32")))]

--- a/tests/proptest_utils.rs
+++ b/tests/proptest_utils.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Property-based coverage for the path and URL helpers. Hand-written

--- a/tests/url_codec_test.rs
+++ b/tests/url_codec_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![cfg(all(test, not(target_arch = "wasm32")))]

--- a/tests/utils_test.rs
+++ b/tests/utils_test.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Integration tests for utils module.

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Integration tests that exercise the public API in a real browser.

--- a/tests/wasm/README.md
+++ b/tests/wasm/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/tests/wasm/common.rs
+++ b/tests/wasm/common.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Shared helpers for browser tests: fresh DOM root, render flush, route

--- a/tests/wasm/nav_link.rs
+++ b/tests/wasm/nav_link.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Browser tests for `NavLink`. Each `#[wasm_bindgen_test]` renders a


### PR DESCRIPTION
Closes #211

The MIT license text lagged the SPDX headers by a year (`2024-2025` vs `2024-2026`). Bumping the range only defers the same drift. Following the [curl 2023 approach](https://daniel.haxx.se/blog/2023/01/08/copyright-without-years/), the year is removed from the copyright notice entirely — nothing left to keep in sync.

## Changes
| File(s) | Before | After |
|---|---|---|
| `LICENSES/MIT.txt` (root `LICENSE` symlink) | `Copyright (c) 2024-2025 RAprogramm` | `Copyright (c) RAprogramm` |
| all SPDX headers (152 files) | `SPDX-FileCopyrightText: 2024-2026 RAprogramm <…>` | `SPDX-FileCopyrightText: RAprogramm <…>` |
| `REUSE.toml` | `= "2024-2026 RAprogramm <…>"` | `= "RAprogramm <…>"` |

## Verification
| Gate | Result |
|---|---|
| `reuse lint` | REUSE 3.3, 152/152 |
| `cargo +nightly fmt --check` | clean |
| `cargo test` | 63 passed, 0 failed |
| `cargo clippy --all-targets -- -W clippy::pedantic -W clippy::nursery` | 0 warnings |