### PR TITLE
#213 fix: render class attribute instead of classes shorthand

### DIFF
--- a/example/e2e/tests/class-attribute.spec.ts
+++ b/example/e2e/tests/class-attribute.spec.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+import { test, expect } from '@playwright/test';
+
+// Regression guard for the `html!` `{classes}` shorthand footgun: it renders
+// a bogus `classes="…"` attribute instead of `class="…"`, so styling silently
+// breaks. No element in the demo should ever carry a `classes` attribute.
+// Complements the static guard (tests/html_class_shorthand_guard.rs) and the
+// wasm DOM tests by proving the real, trunk-built demo is styled correctly.
+
+const ROUTES = ['/', '/navlink', '/components', '/hooks', '/utilities'];
+
+test.describe('class attribute integrity', () => {
+  for (const route of ROUTES) {
+    test(`no bogus "classes" attribute on ${route}`, async ({ page }) => {
+      await page.goto(route);
+      await expect(page.locator('nav').first()).toBeVisible();
+      await expect(page.locator('[classes]')).toHaveCount(0);
+    });
+  }
+
+  test('affected components expose real class names on /components', async ({ page }) => {
+    await page.goto('/components');
+
+    await expect(page.locator('ul.pagination').first()).toBeVisible();
+    await expect(page.locator('.nav-badge').first()).toBeVisible();
+    await expect(page.locator('.nav-dropdown').first()).toBeVisible();
+  });
+});

--- a/src/components/badge.rs
+++ b/src/components/badge.rs
@@ -103,7 +103,7 @@ pub fn NavBadge(props: &NavBadgeProps) -> Html {
     classes.push(variant_class(props.variant));
 
     html! {
-        <span {classes}>
+        <span class={classes}>
             { for props.children.iter() }
         </span>
     }

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -138,7 +138,7 @@ pub fn NavDropdown(props: &NavDropdownProps) -> Html {
     };
 
     html! {
-        <li {classes} role="presentation">
+        <li class={classes} role="presentation">
             <button
                 type="button"
                 class="nav-dropdown-toggle"

--- a/src/components/header.rs
+++ b/src/components/header.rs
@@ -82,13 +82,13 @@ pub fn NavHeader(props: &NavHeaderProps) -> Html {
 
     if let Some(text) = props.text {
         html! {
-            <li {classes} role="presentation">
+            <li class={classes} role="presentation">
                 <span class="nav-header-text">{ text }</span>
             </li>
         }
     } else {
         html! {
-            <li {classes} role="presentation">
+            <li class={classes} role="presentation">
                 { for props.children.iter() }
             </li>
         }

--- a/src/components/icon.rs
+++ b/src/components/icon.rs
@@ -177,7 +177,7 @@ pub fn NavLinkWithIcon(props: &NavLinkWithIconProps) -> Html {
     classes.push("nav-link-with-icon");
 
     html! {
-        <span {classes}>
+        <span class={classes}>
             { for props.children.iter() }
         </span>
     }

--- a/src/components/page_item.rs
+++ b/src/components/page_item.rs
@@ -99,7 +99,7 @@ pub fn PageItem(props: &PageItemProps) -> Html {
     }
 
     html! {
-        <li {classes}>
+        <li class={classes}>
             <span class="page-link">
                 { for props.children.iter() }
             </span>

--- a/src/components/page_link.rs
+++ b/src/components/page_link.rs
@@ -79,13 +79,13 @@ pub fn PageLink(props: &PageLinkProps) -> Html {
 
     if let Some(href) = props.href {
         html! {
-            <a {href} {classes}>
+            <a {href} class={classes}>
                 { for props.children.iter() }
             </a>
         }
     } else {
         html! {
-            <span {classes}>
+            <span class={classes}>
                 { for props.children.iter() }
             </span>
         }

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -136,7 +136,7 @@ pub fn Pagination(props: &PaginationProps) -> Html {
 
     html! {
         <nav aria-label="pagination">
-            <ul {classes}>
+            <ul class={classes}>
                 if show_prev_next {
                     <li class="pagination-item">
                         <button

--- a/src/components/tab_item.rs
+++ b/src/components/tab_item.rs
@@ -122,7 +122,7 @@ pub fn NavTab(props: &NavTabProps) -> Html {
     });
 
     html! {
-        <li {classes} role="presentation">
+        <li class={classes} role="presentation">
             <button
                 type="button"
                 role="tab"

--- a/src/components/tab_panel.rs
+++ b/src/components/tab_panel.rs
@@ -89,7 +89,7 @@ pub fn NavTabPanel(props: &NavTabPanelProps) -> Html {
 
     html! {
         <div
-            {classes}
+            class={classes}
             id={props.id}
             role="tabpanel"
             aria-labelledby={props.labelled_by}

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -92,7 +92,7 @@ pub fn NavTabs(props: &NavTabsProps) -> Html {
 
     html! {
         <ul
-            {classes}
+            class={classes}
             id={props.id}
             role={props.role}
         >

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -69,7 +69,7 @@ pub fn NavText(props: &NavTextProps) -> Html {
     classes.push("nav-text");
 
     html! {
-        <span {classes}>
+        <span class={classes}>
             { props.text }
         </span>
     }

--- a/src/nav/divider.rs
+++ b/src/nav/divider.rs
@@ -92,13 +92,13 @@ pub fn NavDivider(props: &NavDividerProps) -> Html {
 
     if let Some(text) = props.text {
         html! {
-            <li {classes} role="separator">
+            <li class={classes} role="separator">
                 <span class="nav-divider-text">{ text }</span>
             </li>
         }
     } else {
         html! {
-            <li {classes} role="separator" />
+            <li class={classes} role="separator" />
         }
     }
 }

--- a/src/nav/item.rs
+++ b/src/nav/item.rs
@@ -89,13 +89,13 @@ pub fn NavItem(props: &NavItemProps) -> Html {
     if props.disabled {
         classes.push("disabled");
         html! {
-            <li {classes} role="listitem" aria-disabled="true">
+            <li class={classes} role="listitem" aria-disabled="true">
                 { for props.children.iter() }
             </li>
         }
     } else {
         html! {
-            <li {classes} role="listitem">
+            <li class={classes} role="listitem">
                 { for props.children.iter() }
             </li>
         }

--- a/tests/html_class_shorthand_guard.rs
+++ b/tests/html_class_shorthand_guard.rs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Root-cause guard against a silent Yew footgun.
+//!
+//! In `html!`, the shorthand `<el {classes}>` expands to `classes={classes}`.
+//! Yew only maps a prop literally named `class` onto the DOM `class`
+//! attribute, so `{classes}` renders a bogus `classes="…"` attribute that
+//! browsers ignore for styling — the element silently loses every CSS class.
+//! `Classes` implements `IntoPropValue<Option<AttrValue>>`, so the mistake
+//! compiles cleanly and no type check catches it.
+//!
+//! This test scans the crate source and fails if the shorthand ever
+//! reappears, forcing the correct `class={classes}` form. It runs natively in
+//! `cargo nextest`, so every CI platform enforces it without a browser.
+
+use std::{fs, path::Path};
+
+const SHORTHAND: &str = "{classes}";
+const CORRECT_PREFIX: &str = "class={classes}";
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let entries = fs::read_dir(dir).expect("src/ must be readable");
+    for entry in entries {
+        let path = entry.expect("dir entry must be readable").path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn no_bare_classes_shorthand_in_src() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src, &mut files);
+    assert!(!files.is_empty(), "expected to scan at least one src file");
+
+    let mut violations: Vec<String> = Vec::new();
+    for file in &files {
+        let contents = fs::read_to_string(file).expect("source file must be readable");
+        for (line_no, line) in contents.lines().enumerate() {
+            let mut search_from = 0;
+            while let Some(offset) = line[search_from..].find(SHORTHAND) {
+                let idx = search_from + offset;
+                let preceded_by_class = idx >= CORRECT_PREFIX.len() - SHORTHAND.len()
+                    && line[..idx].ends_with("class=");
+                if !preceded_by_class {
+                    violations.push(format!(
+                        "{}:{}: `{}` renders a bogus `classes` attribute; use `class={{classes}}`",
+                        file.display(),
+                        line_no + 1,
+                        line.trim()
+                    ));
+                }
+                search_from = idx + SHORTHAND.len();
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "found {} bare `{{classes}}` shorthand(s); the CSS class would be silently dropped:\n{}",
+        violations.len(),
+        violations.join("\n")
+    );
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -19,3 +19,6 @@ mod common;
 
 #[path = "wasm/nav_link.rs"]
 mod nav_link;
+
+#[path = "wasm/components.rs"]
+mod components;

--- a/tests/wasm/components.rs
+++ b/tests/wasm/components.rs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Browser tests locking in that render-only components emit a real `class`
+//! attribute — not the bogus `classes` attribute produced by the `html!`
+//! `{classes}` shorthand. See `tests/html_class_shorthand_guard.rs` for the
+//! static counterpart.
+
+use wasm_bindgen_test::*;
+use yew::prelude::*;
+use yew_nav_link::{NavBadge, NavItem};
+
+use super::common::{document, fresh_root, wait_for_render};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[function_component]
+fn ItemApp() -> Html {
+    html! { <NavItem>{ "Home" }</NavItem> }
+}
+
+#[function_component]
+fn BadgeApp() -> Html {
+    html! { <NavBadge>{ "9" }</NavBadge> }
+}
+
+#[wasm_bindgen_test]
+async fn nav_item_emits_class_not_classes() {
+    let root = fresh_root();
+    yew::Renderer::<ItemApp>::with_root(root).render();
+    wait_for_render().await;
+
+    let li = document()
+        .query_selector("li")
+        .unwrap()
+        .expect("NavItem should render an <li>");
+
+    assert_eq!(
+        li.get_attribute("class").as_deref(),
+        Some("nav-item"),
+        "NavItem must expose its base class via the `class` attribute"
+    );
+    assert!(
+        li.get_attribute("classes").is_none(),
+        "NavItem must not render a bogus `classes` attribute"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn nav_badge_emits_class_not_classes() {
+    let root = fresh_root();
+    yew::Renderer::<BadgeApp>::with_root(root).render();
+    wait_for_render().await;
+
+    let span = document()
+        .query_selector("span")
+        .unwrap()
+        .expect("NavBadge should render a <span>");
+
+    let class = span
+        .get_attribute("class")
+        .expect("NavBadge must expose its classes via the `class` attribute");
+    assert!(
+        class.contains("nav-badge"),
+        "NavBadge `class` should contain the base class, got {class:?}"
+    );
+    assert!(
+        span.get_attribute("classes").is_none(),
+        "NavBadge must not render a bogus `classes` attribute"
+    );
+}


### PR DESCRIPTION
## Problem

13 components used the `html!` shorthand `<el {classes}>`, which expands to `classes={classes}`. Yew only maps a prop literally named `class` onto the DOM `class` attribute, so these elements rendered a bogus `classes="…"` attribute that browsers ignore — every base class (`nav-item`, `nav-dropdown`, `pagination`, `nav-tabs`, `nav-badge`, …) and any consumer-supplied class was silently dropped. It compiled cleanly because `Classes` implements `IntoPropValue<Option<AttrValue>>`, and the existing wasm DOM tests only covered `NavLink` (already correct), so nothing caught it.

## Fix

All 17 affected sites now use `class={classes}`.

## Root-cause prevention (so it cannot recur)

- **Static guard** (`tests/html_class_shorthand_guard.rs`): a native test that scans `src/` and fails if the bare `{classes}` shorthand reappears. Runs in `cargo nextest` on every CI platform, no browser needed. Verified it fails on reintroduction and passes on the fix.
- **Browser tests** (`tests/wasm/components.rs`): assert `NavItem`/`NavBadge` expose a real `class` attribute and no `classes` attribute. Pass headless under Firefox.
- **E2E guard** (`example/e2e/tests/class-attribute.spec.ts`): asserts no element in the trunk-built demo carries a `classes` attribute across all routes, and affected components expose their real classes. Pass on Chromium.

## Verification

- `cargo nextest`: 457 passed.
- `cargo clippy --all-targets --all-features -D warnings`, `cargo +nightly fmt --check`: clean.
- `wasm-pack test --headless --firefox`: 7 passed.
- Playwright (chromium): 6 passed.

Closes #213