### PR TITLE
#221 chore: sync sub-crate lockfiles and guard version drift

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.10.8"
+version = "0.10.10"
 dependencies = [
  "yew",
  "yew-router",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.10.4"
+version = "0.10.10"
 dependencies = [
  "yew",
  "yew-router",

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -52,6 +52,10 @@ sync_file example/src/lib.rs "$snippet"
 sync_file README.md "s/\\| Rust \\| [0-9]+\\.[0-9]+\\+ \\|/| Rust | ${msrv}+ |/"
 sync_file docs/REQUIREMENTS.md "s/Rust \\*\\*[0-9]+\\.[0-9]+\\+\\*\\*/Rust **${msrv}+**/"
 
+lock_expr="/^name = \"yew-nav-link\"\$/{n;s/^version = \"[0-9]+\\.[0-9]+\\.[0-9]+\"/version = \"${version}\"/}"
+sync_file example/Cargo.lock "$lock_expr"
+sync_file fuzz/Cargo.lock "$lock_expr"
+
 if [ "$STALE" = "1" ]; then
   exit 1
 fi


### PR DESCRIPTION
## Problem

Root crate is `0.10.10`, but the member lockfiles pinned stale versions of the local path dependency: `example/Cargo.lock` at 0.10.8, `fuzz/Cargo.lock` at 0.10.4. `scripts/sync-versions.sh` (run `--check` in CI and pre-commit) synced doc/snippet versions but not the sub-crate lockfiles, so the drift went unnoticed.

## Change

- Regenerated `example/Cargo.lock` and `fuzz/Cargo.lock` to `0.10.10` (only the `yew-nav-link` pin changes).
- Extended `scripts/sync-versions.sh` to sync and `--check` the `yew-nav-link` version pin in both lockfiles, so CI (`ci.yml`) and `.hooks/pre-commit` now fail on this drift automatically.

## Verification

- `./scripts/sync-versions.sh --check` passes; fails on an injected stale pin and fix mode restores it.
- Lockfiles regenerated by cargo itself (authoritative, no other dependency changes).

Closes #221