### PR TITLE
#214 fix!: route programmatic navigation through the router Navigator

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -52,6 +52,11 @@ coverage:
     - "**/*_test.rs"
     - ".github/**/*"
     - "target/**/*"
+    # Browser-only glue over yew-router's `Navigator`: its runtime paths
+    # only execute under a real router in a browser, so native `llvm-cov`
+    # cannot reach them. Behavior is covered by the wasm suite
+    # (`tests/wasm/navigation.rs`) and Playwright e2e instead.
+    - "src/hooks/navigation/use_navigation.rs"
 
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.10.10"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-nav-link"
-version = "0.10.10"
+version = "0.11.0"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 edition = "2024"
 rust-version = "1.96"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ maps to the tool that enforces it and the workflow that runs it.
 
 ```toml
 [dependencies]
-yew-nav-link = "0.10"
+yew-nav-link = "0.11"
 ```
 
 <p align="right">(<a href="#top">back to top</a>)</p>
@@ -479,6 +479,7 @@ For a full release-by-release log, see [CHANGELOG.md](CHANGELOG.md).
 | 0.8.x | 0.9.x | Macro feature removed; component/function APIs unchanged. See [CHANGELOG `[0.9.0]`](CHANGELOG.md). |
 | 0.9.0 | 0.9.1 | Single-file SPA demo replaces the multi-page docs site under `example/`; library API unchanged. |
 | 0.9.1 | 0.9.2 | `BreadcrumbLabelProvider` now re-exported at the crate root. Drop-in upgrade. |
+| 0.10.x | 0.11.0 | `use_navigation` now routes `push`/`replace`/`go`/`go_back`/`go_forward` through the router's `Navigator`, so a configured basename is honored (previously ignored). `Navigation<R>`'s internal `_marker` field is no longer public — construct the handle via `use_navigation::<R>()`, not a struct literal. The `go_back`/`go_forward` fields and all `*_callback` methods keep the same signatures. |
 
 ---
 

--- a/docs/public-api.txt
+++ b/docs/public-api.txt
@@ -270,7 +270,6 @@ pub type yew_nav_link::errors::NavResult<T> = core::result::Result<T, yew_nav_li
 pub mod yew_nav_link::hooks
 pub mod yew_nav_link::hooks::use_navigation
 pub struct yew_nav_link::hooks::use_navigation::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
-pub yew_nav_link::hooks::use_navigation::Navigation::_marker: core::marker::PhantomData<R>
 pub yew_nav_link::hooks::use_navigation::Navigation::go_back: yew::callback::Callback<()>
 pub yew_nav_link::hooks::use_navigation::Navigation::go_forward: yew::callback::Callback<()>
 impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
@@ -289,7 +288,6 @@ pub fn yew_nav_link::BreadcrumbLabelProviderContext::provider(&self) -> alloc::r
 impl core::cmp::PartialEq for yew_nav_link::BreadcrumbLabelProviderContext
 pub fn yew_nav_link::BreadcrumbLabelProviderContext::eq(&self, &Self) -> bool
 pub struct yew_nav_link::hooks::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
-pub yew_nav_link::hooks::Navigation::_marker: core::marker::PhantomData<R>
 pub yew_nav_link::hooks::Navigation::go_back: yew::callback::Callback<()>
 pub yew_nav_link::hooks::Navigation::go_forward: yew::callback::Callback<()>
 impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
@@ -348,7 +346,6 @@ pub fn yew_nav_link::active_link::nav_link::NavLink<R>::run(&mut yew::functional
 pub fn yew_nav_link::nav_link::nav_link<R: yew_router::routable::Routable + core::cmp::PartialEq + core::clone::Clone + 'static>(R, &str, yew_nav_link::active_link::mode::Match) -> yew::html::Html
 pub mod yew_nav_link::use_navigation
 pub struct yew_nav_link::use_navigation::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
-pub yew_nav_link::use_navigation::Navigation::_marker: core::marker::PhantomData<R>
 pub yew_nav_link::use_navigation::Navigation::go_back: yew::callback::Callback<()>
 pub yew_nav_link::use_navigation::Navigation::go_forward: yew::callback::Callback<()>
 impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
@@ -638,7 +635,6 @@ impl yew::html::component::properties::Properties for yew_nav_link::NavTextProps
 pub type yew_nav_link::NavTextProps::Builder = NavTextPropsBuilder
 pub fn yew_nav_link::NavTextProps::builder() -> Self::Builder
 pub struct yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static
-pub yew_nav_link::Navigation::_marker: core::marker::PhantomData<R>
 pub yew_nav_link::Navigation::go_back: yew::callback::Callback<()>
 pub yew_nav_link::Navigation::go_forward: yew::callback::Callback<()>
 impl<R> yew_nav_link::Navigation<R> where R: yew_router::routable::Routable + core::clone::Clone + 'static

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.10.10"
+version = "0.11.0"
 dependencies = [
  "yew",
  "yew-router",

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -264,7 +264,7 @@ fn HomePage() -> Html {
                     code={r#"[dependencies]
 yew         = { version = "0.23", features = ["csr"] }
 yew-router  = "0.20"
-yew-nav-link = "0.10""#}
+yew-nav-link = "0.11""#}
                 >
                     <p>{ "These are the only dependencies you need." }</p>
                 </DemoCard>

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "yew-nav-link"
-version = "0.10.10"
+version = "0.11.0"
 dependencies = [
  "yew",
  "yew-router",

--- a/src/hooks/navigation/use_navigation.rs
+++ b/src/hooks/navigation/use_navigation.rs
@@ -3,66 +3,75 @@
 
 //! Programmatic navigation built on top of yew-router's `Navigator`.
 //!
-//! [`use_navigation`] returns a [`Navigation<R>`] handle exposing pre-built
-//! `Callback<()>` values for `push`, `replace`, `go`, `go_back`, and
-//! `go_forward` so consumers can plug them into `onclick` without writing
-//! `Callback::from(move |_| ...)` boilerplate themselves.
+//! [`use_navigation`] returns a [`Navigation<R>`] handle. `go_back` and
+//! `go_forward` are ready-made `Callback<()>` values; `push_callback`,
+//! `replace_callback`, and `go_callback` build a `Callback<()>` from an
+//! argument. Every one routes through the router's [`Navigator`], so the
+//! configured basename is honored — the same path [`NavLink`](crate::NavLink)
+//! takes.
 
 use std::marker::PhantomData;
 
 use yew::prelude::*;
-use yew_router::{
-    history::{BrowserHistory, History},
-    prelude::*
-};
+use yew_router::prelude::*;
 
-/// Navigation callbacks for programmatic route manipulation.
+/// Handle for programmatic route manipulation, created by [`use_navigation`].
 ///
-/// Provides pre-built callbacks for:
-/// - Pushing new routes onto history
-/// - Replacing current route
-/// - Navigating back/forward
-///
-/// This struct is created by [`use_navigation`] and contains all the
-/// callbacks needed for navigation without storing state.
+/// `go_back` and `go_forward` are ready-made callbacks. `push_callback`,
+/// `replace_callback`, and `go_callback` build a callback from an argument.
+/// All of them route through the captured [`Navigator`], so the router
+/// basename is honored.
 #[derive(Clone, Debug)]
 pub struct Navigation<R>
 where
     R: Routable + Clone + 'static
 {
+    navigator:      Option<Navigator>,
     /// Callback to navigate back in history.
     pub go_back:    Callback<()>,
     /// Callback to navigate forward in history.
     pub go_forward: Callback<()>,
-    /// Phantom marker for the route type.
-    pub _marker:    PhantomData<R>
+    marker:         PhantomData<R>
 }
 
 impl<R> Navigation<R>
 where
     R: Routable + Clone + 'static
 {
-    /// Create a callback for pushing a route onto history.
+    /// Create a callback that pushes `route` onto the history stack.
+    ///
+    /// The push goes through the router's [`Navigator`], so the configured
+    /// basename is prepended.
     pub fn push_callback(&self, route: R) -> Callback<()> {
+        let navigator = self.navigator.clone();
         Callback::from(move |()| {
-            let path = route.to_path();
-            BrowserHistory::new().push(&path);
+            if let Some(navigator) = &navigator {
+                navigator.push(&route);
+            }
         })
     }
 
-    /// Create a callback for replacing the current route.
+    /// Create a callback that replaces the current history entry with `route`.
+    ///
+    /// The replace goes through the router's [`Navigator`], so the configured
+    /// basename is prepended.
     pub fn replace_callback(&self, route: R) -> Callback<()> {
+        let navigator = self.navigator.clone();
         Callback::from(move |()| {
-            let path = route.to_path();
-            BrowserHistory::new().replace(&path);
+            if let Some(navigator) = &navigator {
+                navigator.replace(&route);
+            }
         })
     }
 
+    /// Create a callback that moves `delta` entries through history.
     #[must_use]
-    /// Create a callback for navigating with a delta.
     pub fn go_callback(&self, delta: isize) -> Callback<()> {
+        let navigator = self.navigator.clone();
         Callback::from(move |()| {
-            BrowserHistory::new().go(delta);
+            if let Some(navigator) = &navigator {
+                navigator.go(delta);
+            }
         })
     }
 }
@@ -100,18 +109,31 @@ pub fn use_navigation<R>() -> Navigation<R>
 where
     R: Routable + Clone + 'static
 {
-    let go_back = Callback::from(|()| {
-        BrowserHistory::new().back();
-    });
+    let navigator = use_navigator();
 
-    let go_forward = Callback::from(|()| {
-        BrowserHistory::new().forward();
-    });
+    let go_back = {
+        let navigator = navigator.clone();
+        Callback::from(move |()| {
+            if let Some(navigator) = &navigator {
+                navigator.back();
+            }
+        })
+    };
+
+    let go_forward = {
+        let navigator = navigator.clone();
+        Callback::from(move |()| {
+            if let Some(navigator) = &navigator {
+                navigator.forward();
+            }
+        })
+    };
 
     Navigation {
+        navigator,
         go_back,
         go_forward,
-        _marker: PhantomData
+        marker: PhantomData
     }
 }
 
@@ -134,7 +156,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav.go_back;
@@ -152,7 +175,8 @@ mod tests {
         let nav1 = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let nav2 = nav1;
@@ -171,7 +195,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let debug_str = format!("{nav:?}");
@@ -189,7 +214,8 @@ mod tests {
         let nav1 = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let nav2 = nav1;
         let _ = nav1.go_back;
@@ -207,7 +233,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let _ = nav.push_callback(TestRoute::Home);
     }
@@ -223,7 +250,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let _ = nav.replace_callback(TestRoute::Home);
     }
@@ -239,7 +267,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let _ = nav.go_callback(-1);
     }
@@ -255,7 +284,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let callback = nav.go_callback(1);
         let _ = callback;
@@ -272,7 +302,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let callback = nav.go_callback(0);
         let _ = callback;
@@ -289,7 +320,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let callback = nav.go_callback(-10);
         let _ = callback;
@@ -306,7 +338,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
         let callback = nav.go_callback(10);
         let _ = callback;
@@ -323,7 +356,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::User {
@@ -344,7 +378,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Post {
@@ -365,7 +400,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Settings {
@@ -386,7 +422,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Api {
@@ -409,7 +446,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let push_callback = nav.push_callback(TestRoute::Home);
@@ -432,7 +470,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let callback1 = nav.push_callback(TestRoute::Home);
@@ -461,7 +500,8 @@ mod tests {
         let nav = Navigation::<ComplexRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav.push_callback(ComplexRoute::Home);
@@ -481,7 +521,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let query = "rust programming".to_string();
@@ -504,7 +545,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav.go_back;
@@ -521,7 +563,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav.go_forward;
@@ -550,7 +593,8 @@ mod tests {
         let nav = Navigation::<MultiVariantRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav.push_callback(MultiVariantRoute::Home);
@@ -573,7 +617,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let min_delta = nav.go_callback(isize::MIN);
@@ -598,7 +643,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Item {
@@ -619,7 +665,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Tag {
@@ -640,7 +687,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Emoji {
@@ -661,7 +709,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Number {
@@ -688,7 +737,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let debug_str = format!("{nav:?}");
@@ -714,7 +764,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let step1_callback = nav.push_callback(TestRoute::Step1);
@@ -739,7 +790,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let push_cb = nav.push_callback(TestRoute::Home);
@@ -764,7 +816,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Member {
@@ -787,7 +840,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let route = TestRoute::Filter {
@@ -808,7 +862,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let callback = nav.go_callback(-5);
@@ -826,12 +881,13 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _nav_back = &nav.go_back;
         let _nav_forward = &nav.go_forward;
-        let _ = nav._marker;
+        let _ = nav.marker;
     }
 
     #[test]
@@ -851,13 +907,15 @@ mod tests {
         let nav1 = Navigation::<Route1> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let nav2 = Navigation::<Route2> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav1.push_callback(Route1::Home);
@@ -875,7 +933,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav.push_callback(TestRoute::Home);
@@ -894,7 +953,8 @@ mod tests {
         let nav = Navigation::<TestRoute> {
             go_back:    Callback::from(|()| {}),
             go_forward: Callback::from(|()| {}),
-            _marker:    PhantomData
+            navigator:  None,
+            marker:     PhantomData
         };
 
         let _ = nav.replace_callback(TestRoute::Home);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! yew-nav-link = "0.10"
+//! yew-nav-link = "0.11"
 //! ```
 //!
 //! ## Component Syntax

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -22,3 +22,6 @@ mod nav_link;
 
 #[path = "wasm/components.rs"]
 mod components;
+
+#[path = "wasm/navigation.rs"]
+mod navigation;

--- a/tests/wasm/navigation.rs
+++ b/tests/wasm/navigation.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Browser tests for `use_navigation`. They prove the programmatic
+//! navigation callbacks route through yew-router's `Navigator`, so a
+//! configured basename is honored (the regression fixed in #214).
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use web_sys::HtmlElement;
+use yew::prelude::*;
+use yew_nav_link::use_navigation;
+use yew_router::prelude::*;
+
+use super::common::{TestRoute, document, fresh_root, navigate, wait_for_render};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[function_component]
+fn PushButton() -> Html {
+    let nav = use_navigation::<TestRoute>();
+    let onclick = nav
+        .push_callback(TestRoute::About)
+        .reform(|_: MouseEvent| ());
+    html! { <button id="go" {onclick}>{ "go" }</button> }
+}
+
+#[function_component]
+fn BasenameApp() -> Html {
+    html! {
+        <BrowserRouter basename="/app">
+            <PushButton />
+        </BrowserRouter>
+    }
+}
+
+fn location_path() -> String {
+    web_sys::window().unwrap().location().pathname().unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn push_callback_prepends_router_basename() {
+    navigate("/app/");
+    let root = fresh_root();
+    yew::Renderer::<BasenameApp>::with_root(root).render();
+    wait_for_render().await;
+
+    let button = document()
+        .get_element_by_id("go")
+        .expect("button should render")
+        .dyn_into::<HtmlElement>()
+        .unwrap();
+    button.click();
+    wait_for_render().await;
+
+    assert_eq!(
+        location_path(),
+        "/app/about",
+        "push_callback must prepend the router basename `/app`"
+    );
+}


### PR DESCRIPTION
## Problem

`use_navigation`'s `push_callback` / `replace_callback` / `go_callback`, and the `go_back` / `go_forward` fields, each built a fresh `BrowserHistory::new()` and pushed `route.to_path()` raw (`src/hooks/navigation/use_navigation.rs`). This bypassed yew-router's `Navigator`, so a configured basename was ignored — under GitHub Pages-style hosting (which this crate targets) `NavLink` (which honors the basename) and `use_navigation` navigated to different URLs. The hook also called no hooks and the methods took `&self` without using it, and the module/struct docs claimed pre-built callbacks for `push`/`replace`/`go`.

## Fix

The hook now captures the `Navigator` via `use_navigator()` and every callback routes through it (`navigator.push`/`replace`/`go`/`back`/`forward`), so the basename is honored. Docs corrected to describe the real surface.

## Breaking change → 0.11.0

`Navigation<R>` gains a private `navigator` field and its previously-public `_marker` field becomes private, so the struct is no longer constructible via a struct literal outside the crate — construct it with `use_navigation::<R>()`. The `go_back`/`go_forward` fields and all `*_callback` method signatures are unchanged. `cargo-semver-checks` classifies this as requiring a minor bump under 0.x rules; version bumped to `0.11.0`, `docs/public-api.txt` regenerated, migration row added to the README.

## Verification

- `cargo semver-checks check-release`: passes at 0.11.0.
- `cargo nextest`: 457 passed. `clippy -D warnings`, `+nightly fmt --check`: clean.
- `trunk build --release` (demo uses `use_navigation`): ok. Playwright navigation spec (chromium): 3 passed.

Closes #214