### PR TITLE
#218 docs: sync README and docs with the actual public API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Report unacceptable behaviour via the contact in that file.
 
 You need:
 
-- Rust **stable 1.95+** plus a `nightly` toolchain (used only for `rustfmt`):
+- Rust **stable 1.96+** plus a `nightly` toolchain (used only for `rustfmt`):
   ```bash
   rustup default stable
   rustup toolchain install nightly --component rustfmt
@@ -86,11 +86,12 @@ git checkout -b 123
 ### 3. Commit format
 
 ```bash
-git commit -m "#123 feat add custom class support"
+git commit -m "#123 feat: add custom class support"
 ```
 
-Format is `#<issue> <type> <description>` — no colon after the type, no
-`(scope)`. Breaking changes carry a `!` on the type (`feat!`, `refactor!`).
+Format is `#<issue> <type>: <description>` — conventional-commit type with a
+colon, no `(scope)`. Breaking changes carry a `!` on the type (`feat!`,
+`fix!`, `refactor!`).
 
 | Type | Use for | Triggers in CHANGELOG |
 |---|---|---|
@@ -102,13 +103,16 @@ Format is `#<issue> <type> <description>` — no colon after the type, no
 | `test` | Test additions or modifications | no |
 | `chore` | Maintenance, dependency bumps, tooling | no |
 
-`git-cliff` reads these prefixes (`cliff.toml`), normalising the
-`#<N> <type> <desc>` form into a conventional-commit subject for the
-CHANGELOG.
+`git-cliff` and release-plz read these prefixes (`cliff.toml`,
+`release-plz.toml`), normalising the `#<N> <type>: <desc>` form into a
+conventional-commit subject for the CHANGELOG and the version bump.
 
 ### 4. Open a pull request
 
-- **Title:** issue number only (e.g. `123`).
+- **Title:** conventional-commit form matching the commit, e.g.
+  `#123 feat: add custom class support`. The squash-merge uses the PR title
+  as the subject on `main`, and release-plz parses it for the changelog and
+  version bump — a bare issue number would be dropped.
 - **Body:** must include `Closes #123` so the issue auto-closes on merge.
 - **Reviews:** there is no required-reviewer rule on `main`, but every PR
   must pass the `CI Success` aggregate status check before merge — that's
@@ -131,7 +135,7 @@ CHANGELOG.
 | Line width | 99 characters (`max_width` in `.rustfmt.toml`). |
 | Trailing commas | Never (`trailing_comma = "Never"` in `.rustfmt.toml`). |
 | Edition | Rust 2024. |
-| MSRV | 1.95. |
+| MSRV | 1.96. |
 
 ## CI overview
 
@@ -142,13 +146,12 @@ merge.
 | Job | Required | Notes |
 |---|---|---|
 | `Extract MSRV` | yes | reads `rust-version` from `Cargo.toml` |
-| `Check` | yes | matrix: 3 toolchains × 3 OSes |
+| `Check` | yes | matrix: 3 toolchains × 3 OSes; also runs `clippy` (all + no-default features) |
 | `Format` | yes | nightly `rustfmt --check` |
-| `Lint (clippy)` | yes | pedantic + nursery |
 | `Documentation` | yes | `cargo doc --all-features` with `RUSTDOCFLAGS=-D warnings` |
 | `Public API` | yes | `cargo public-api -sss` must match `docs/public-api.txt` |
+| `Semver Checks` | yes | `cargo semver-checks check-release` against the last crates.io release |
 | `Book` | yes | `mdbook build docs` against `docs/book.toml` |
-| `no-std` | yes | informational stub (Yew is std-only) |
 | `Security` | yes | `cargo deny check` + `cargo audit` |
 | `REUSE Compliance` | yes | `reuse lint` |
 | `Test` | yes (skip allowed) | `cargo nextest` + doctests |

--- a/README.md
+++ b/README.md
@@ -311,25 +311,28 @@ fn Crumbs() -> Html {
 
 | Hook | Returns | Description |
 |------|---------|-------------|
-| `use_route_info()` | `RouteInfo<R>` | Current route, path, and query parameters |
+| `use_route_info::<R>()` | `Option<R>` | Currently matched route, or `None` when nothing matches |
 | `use_is_active(route)` | `bool` | Whether the given route is currently active |
 | `use_is_exact_active(route)` | `bool` | Whether the route matches exactly |
 | `use_is_partial_active(route)` | `bool` | Whether the route is a prefix of the current path |
-| `use_breadcrumbs()` | `Vec<BreadcrumbItem<R>>` | Auto-generated breadcrumb trail from current route |
-| `use_navigation<R>()` | `Navigation<R>` | Programmatic navigation (push, replace, go back/forward) |
-| `use_query_params()` | `HashMap<String, String>` | URL query string parameters |
+| `use_breadcrumbs::<R>()` | `Vec<BreadcrumbItem<R>>` | Auto-generated breadcrumb trail from current route |
+| `use_navigation::<R>()` | `Navigation<R>` | Programmatic navigation (push, replace, go back/forward) |
+| `use_query_params()` | `QueryParams` | URL query parameters (multi-value `utils::QueryParams`) |
 
 ### Utilities
 
-| Function | Description |
-|----------|-------------|
-| `is_absolute(path)` | Check if a path starts with `/` |
-| `join_paths(a, b)` | Join two path segments safely |
-| `normalize_path(path)` | Remove duplicate slashes and trailing slashes |
-| `urlencoding_encode(s)` | Percent-encode a string for URLs |
-| `urlencoding_decode(s)` | Decode a percent-encoded string |
-| `handle_arrow_key(config, key)` | Keyboard navigation handler |
-| `handle_home_end(config, key)` | Home/End key handler for navigation |
+Path helpers are re-exported at the crate root; the URL and keyboard helpers
+live under the `utils` module (`yew_nav_link::utils::…`).
+
+| Function | Path | Description |
+|----------|------|-------------|
+| `is_absolute(path)` | crate root | Check if a path starts with `/` |
+| `join_paths(a, b)` | crate root | Join two path segments safely |
+| `normalize_path(path)` | crate root | Collapse duplicate slashes and resolve `.`/`..`; a single trailing slash is preserved |
+| `urlencoding_encode(s)` | `utils::` | Percent-encode a string for URLs |
+| `urlencoding_decode(s)` | `utils::` | Decode a percent-encoded string (`None` on invalid UTF-8) |
+| `handle_arrow_key(config, key)` | `utils::` | Keyboard navigation handler |
+| `handle_home_end(config, key)` | `utils::` | Home/End key handler for navigation |
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
@@ -443,10 +446,13 @@ fn nav_link<R: Routable + PartialEq + Clone + 'static>(
 ### `BreadcrumbItem`
 
 ```rust
-pub struct BreadcrumbItem {
+pub struct BreadcrumbItem<R> {
+    /// The route this breadcrumb points to.
+    pub route: R,
+    /// Human-readable label for the breadcrumb.
     pub label: String,
-    pub route: Option<String>,
-    pub is_current: bool,
+    /// Whether this breadcrumb is the current route.
+    pub is_active: bool,
 }
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,9 @@ Only the two most recent minor versions receive security updates.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.11.x  | :white_check_mark: |
 | 0.10.x  | :white_check_mark: |
-| 0.9.x   | :white_check_mark: |
-| < 0.9   | :x:                |
+| < 0.10  | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -62,13 +62,16 @@ alias return `true` iff the current route equals `route`.
 `route.to_path()` is a path-segment prefix of the current path.
 
 **FR-HK-4.** `use_navigation::<R>() -> Navigation<R>` returns a value-type
-struct exposing pre-built callbacks: `push_callback`, `replace_callback`,
-`go_callback`, `go_back`, `go_forward`. Each callback is `Callback<()>`
-(or `Callback<i32>` for `go_callback`) so consumers can adapt with
-`.reform(...)` for `onclick` handlers.
+struct. `go_back` and `go_forward` are ready-made `Callback<()>` fields;
+`push_callback(route)`, `replace_callback(route)`, and `go_callback(delta:
+isize)` are methods that build a `Callback<()>` from an argument. Every
+callback routes through the router's `Navigator`, so a configured basename
+is honored. Consumers adapt them with `.reform(...)` for `onclick` handlers.
 
-**FR-HK-5.** `use_query_params() -> HashMap<String, String>` parses the
-current URL's query string into a flat map; reactive on every URL change.
+**FR-HK-5.** `use_query_params() -> QueryParams` parses the current URL's
+query string into a multi-value map (`utils::QueryParams`, backed by
+`Vec<(String, Vec<String>)>` so repeated keys are preserved); reactive on
+every URL change.
 
 **FR-HK-6.** `use_breadcrumbs::<R>() -> Vec<BreadcrumbItem<R>>` builds a
 breadcrumb trail from the current path. The label of each item comes from a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,9 +43,8 @@ upgrade through in one hop:
 - Active `NavLink` emits `aria-current="page"` on the rendered `<a>` for
   screen-reader-correct active state.
 
-MSRV review for the line completed with no bump: stable Rust 1.95 was
-the latest stable when 0.10 was cut and remained so through the window
-(see closed issue #71).
+The line's MSRV is Rust 1.96 (`rust-version` in `Cargo.toml`), enforced by
+CI's MSRV matrix on Linux/macOS/Windows.
 
 Subsequent 0.10.x patches address CI, dependency bumps, and
 documentation only — no public API changes.

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -839,7 +839,7 @@ let forward  = nav.go_forward.clone().reform(|_: MouseEvent| ());"#}
                 <DemoCard
                     title="Reactive query string"
                     description="Append ?foo=bar&page=2 to the URL bar and watch this map update without a reload."
-                    code={r#"let query: HashMap<String, String> = use_query_params();
+                    code={r#"let query: QueryParams = use_query_params();
 let page = query.get("page");"#}
                 >
                     <pre class="inline-pre">{ format!("{:#?}", query) }</pre>


### PR DESCRIPTION
## Problem

Hand-maintained docs had drifted from the code (machine baseline: `docs/public-api.txt`).

## Corrections

| Doc | Was | Now |
|---|---|---|
| README hooks table | `use_route_info() -> RouteInfo<R>` | `use_route_info::<R>() -> Option<R>` (no `RouteInfo` type exists) |
| README hooks table | `use_query_params() -> HashMap<String,String>` | `-> QueryParams` (multi-value) |
| README utils table | flat list, `normalize_path` "removes trailing slashes" | crate-root vs `utils::` paths split out; normalize preserves a single trailing slash |
| README `BreadcrumbItem` | `{ label, route: Option<String>, is_current }` | `BreadcrumbItem<R> { route: R, label, is_active }` |
| `docs/REQUIREMENTS.md` FR-HK-4 | push/replace/go "pre-built callbacks", `Callback<i32>` | methods building `Callback<()>` from args; only `go_back`/`go_forward` are fields |
| `docs/REQUIREMENTS.md` FR-HK-5 | `HashMap<String,String>` | `QueryParams` |
| `docs/ROADMAP.md` | MSRV 1.95 "no bump" | MSRV 1.96 (matches `Cargo.toml`) |
| `CONTRIBUTING.md` | MSRV 1.95; commit "no colon"; PR title "issue number only"; `no-std` job; standalone `Lint (clippy)`; no `Semver Checks` | MSRV 1.96; `#N type: desc` with colon; conventional PR title; `no-std` removed; clippy folded into `Check`; `Semver Checks` added |
| `SECURITY.md` | supported 0.10.x / 0.9.x | 0.11.x / 0.10.x (reconciles with ROADMAP's closed 0.9.x line) |
| `example/src/lib.rs` demo | `HashMap<String,String> = use_query_params()` | `QueryParams = use_query_params()` |

The `use_navigation` module docs and the README migration table were already corrected in #214.

## Verification

- `cargo test --doc`: 33 passed. `./scripts/sync-versions.sh --check`: clean. `trunk build --release`: ok.

Closes #218