### PR TITLE
#216 fix: give pagination prev/next buttons an accessible name

### DIFF
--- a/example/e2e/tests/pagination.spec.ts
+++ b/example/e2e/tests/pagination.spec.ts
@@ -18,4 +18,20 @@ test.describe('Pagination', () => {
     const active = pagination.locator('button[aria-current="page"]');
     await expect(active).toHaveCount(1);
   });
+
+  test('prev/next buttons expose an accessible name', async ({ page }) => {
+    await page.goto('/components');
+
+    const pagination = page.locator('nav[aria-label="pagination"]').first();
+    await expect(pagination).toBeVisible();
+
+    // The glyph-only prev/next controls must announce a real name to
+    // assistive tech, not the raw "‹"/"›" characters.
+    await expect(
+      pagination.getByRole('button', { name: 'Previous page' })
+    ).toHaveCount(1);
+    await expect(
+      pagination.getByRole('button', { name: 'Next page' })
+    ).toHaveCount(1);
+  });
 });

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -141,6 +141,7 @@ pub fn Pagination(props: &PaginationProps) -> Html {
                     <li class="pagination-item">
                         <button
                             type="button"
+                            aria-label="Previous page"
                             disabled={current_page <= 1}
                             onclick={on_page_change.clone().map(move |cb| {
                                 let cb = cb.clone();
@@ -210,6 +211,7 @@ pub fn Pagination(props: &PaginationProps) -> Html {
                     <li class="pagination-item">
                         <button
                             type="button"
+                            aria-label="Next page"
                             disabled={current_page >= total_pages}
                             onclick={on_page_change.clone().map(move |cb| {
                                 let cb = cb.clone();


### PR DESCRIPTION
## Problem

The pagination previous/next controls contained only the glyphs `‹`/`›` (`src/components/pagination.rs`), so screen readers announced "single left-pointing angle quotation mark" instead of a meaningful name.

## Fix

Added `aria-label="Previous page"` / `aria-label="Next page"` to the two buttons. The visible glyphs are unchanged; the accessible name now comes from the label.

## Verification

- `cargo nextest`: 460 passed. `clippy -D warnings`, `+nightly fmt --check`: clean.
- New Playwright assertion (`example/e2e/tests/pagination.spec.ts`) locates both controls by their accessible name; chromium: 2 passed.

Closes #216