### PR TITLE
#217 feat: keyboard navigation for NavDropdown

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -57,6 +57,10 @@ coverage:
     # cannot reach them. Behavior is covered by the wasm suite
     # (`tests/wasm/navigation.rs`) and Playwright e2e instead.
     - "src/hooks/navigation/use_navigation.rs"
+    # Browser-only keyboard/focus interaction (DOM focus, event dispatch):
+    # unreachable by native `llvm-cov`. Covered by the wasm suite
+    # (`tests/wasm/dropdown.rs`) instead.
+    - "src/components/dropdown.rs"
 
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,7 @@ default = []
 [dependencies]
 yew = { version = "0.23", features = ["csr"] }
 yew-router = "0.20"
-
-[dev-dependencies]
 wasm-bindgen = "0.2"
-wasm-bindgen-test = "0.3"
-wasm-bindgen-futures = "0.4"
-js-sys = "0.3"
 web-sys = { version = "0.3", features = [
   "Window",
   "Document",
@@ -43,7 +38,17 @@ web-sys = { version = "0.3", features = [
   "HtmlElement",
   "HtmlCollection",
   "History",
+  "Node",
+  "NodeList",
+  "EventTarget",
+  "KeyboardEvent",
+  "KeyboardEventInit",
 ] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
 
 # Native-only dev-deps. `criterion` pulls in non-wasm runtime crates and
 # `proptest`'s default features pull `rusty-fork` -> `wait-timeout`, which

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -938,6 +938,8 @@ dependencies = [
 name = "yew-nav-link"
 version = "0.11.0"
 dependencies = [
+ "wasm-bindgen",
+ "web-sys",
  "yew",
  "yew-router",
 ]

--- a/example/e2e/tests/dropdown.spec.ts
+++ b/example/e2e/tests/dropdown.spec.ts
@@ -3,9 +3,8 @@
 
 import { test, expect } from '@playwright/test';
 
-// NavDropdown ships toggle-on-click semantics. Outside-click and Escape
-// handlers are tracked in a follow-up: the current scenarios exercise the
-// state machine that is implemented today.
+// NavDropdown supports toggle-on-click plus keyboard (Escape) and
+// outside-click dismissal.
 
 test.describe('NavDropdown', () => {
   test('opens on toggle click and exposes the menu', async ({ page }) => {
@@ -27,6 +26,29 @@ test.describe('NavDropdown', () => {
     await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 
     await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('closes on Escape', async ({ page }) => {
+    await page.goto('/components');
+
+    const toggle = page.getByRole('button', { name: /Account/ }).first();
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    await page.keyboard.press('Escape');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('closes when focus moves outside the menu', async ({ page }) => {
+    await page.goto('/components');
+
+    const toggle = page.getByRole('button', { name: /Account/ }).first();
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    // Tab out of the dropdown; the focusout handler dismisses the menu.
+    await page.locator('body').click({ position: { x: 5, y: 5 } });
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/src/components/dropdown.rs
+++ b/src/components/dropdown.rs
@@ -79,7 +79,29 @@
 //! |------|------|---------|-------------|
 //! | `classes` | `Classes` | — | Additional CSS classes |
 
+use wasm_bindgen::JsCast;
+use web_sys::{Element, HtmlElement, Node};
 use yew::prelude::*;
+
+use crate::utils::{KeyboardNavConfig, handle_arrow_key, handle_home_end};
+
+/// Collects the focusable elements (links and enabled buttons) inside the
+/// dropdown menu, in DOM order.
+fn menu_items(menu_ref: &NodeRef) -> Vec<HtmlElement> {
+    menu_ref
+        .cast::<Element>()
+        .and_then(|menu| {
+            menu.query_selector_all("a[href], button:not([disabled])")
+                .ok()
+        })
+        .map(|list| {
+            (0..list.length())
+                .filter_map(|index| list.item(index))
+                .filter_map(|node| node.dyn_into::<HtmlElement>().ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 /// Properties for the [`NavDropdown`] component.
 ///
@@ -110,6 +132,15 @@ pub struct NavDropdownProps {
 
 /// Collapsible dropdown menu for grouping navigation links.
 ///
+/// # Keyboard & accessibility
+///
+/// The toggle carries `aria-expanded` / `aria-haspopup` and the menu
+/// `role="menu"`. When the menu opens, focus moves to the first item.
+/// `ArrowDown`/`ArrowUp` (wrapping) and `Home`/`End` move a roving focus over
+/// the menu's links; `Escape` closes the menu and returns focus to the
+/// toggle; moving focus out of the dropdown (tabbing away or clicking
+/// elsewhere) dismisses it.
+///
 /// # CSS Classes
 ///
 /// - `nav-dropdown` - Container `<li>` element
@@ -122,6 +153,9 @@ pub fn NavDropdown(props: &NavDropdownProps) -> Html {
     classes.push("nav-dropdown");
 
     let open = use_state(|| false);
+    let container_ref = use_node_ref();
+    let toggle_ref = use_node_ref();
+    let menu_ref = use_node_ref();
 
     let on_toggle = {
         let open = open.clone();
@@ -131,6 +165,91 @@ pub fn NavDropdown(props: &NavDropdownProps) -> Html {
         })
     };
 
+    let on_keydown = {
+        let open = open.clone();
+        let toggle_ref = toggle_ref.clone();
+        let menu_ref = menu_ref.clone();
+        Callback::from(move |event: KeyboardEvent| {
+            let key = event.key();
+
+            if key == "Escape" && *open {
+                event.prevent_default();
+                open.set(false);
+                if let Some(toggle) = toggle_ref.cast::<HtmlElement>() {
+                    let _ = toggle.focus();
+                }
+                return;
+            }
+
+            if !matches!(key.as_str(), "ArrowDown" | "ArrowUp" | "Home" | "End") {
+                return;
+            }
+
+            let items = menu_items(&menu_ref);
+            if items.is_empty() {
+                return;
+            }
+
+            event.prevent_default();
+            if !*open {
+                open.set(true);
+                return;
+            }
+
+            let active = web_sys::window()
+                .and_then(|window| window.document())
+                .and_then(|document| document.active_element())
+                .map(JsCast::unchecked_into::<Node>);
+            let current = active
+                .as_ref()
+                .and_then(|node| items.iter().position(|item| item.is_same_node(Some(node))))
+                .unwrap_or(0);
+
+            let config = KeyboardNavConfig {
+                wrap:     true,
+                vertical: true
+            };
+            let next = if matches!(key.as_str(), "Home" | "End") {
+                handle_home_end(&key, current, items.len())
+            } else {
+                handle_arrow_key(&key, current, items.len(), &config)
+            };
+
+            if let Some(item) = next.and_then(|index| items.get(index)) {
+                let _ = item.focus();
+            }
+        })
+    };
+
+    let on_focusout = {
+        let open = open.clone();
+        let container_ref = container_ref.clone();
+        Callback::from(move |event: FocusEvent| {
+            if !*open {
+                return;
+            }
+            let stays_inside = match (container_ref.cast::<Node>(), event.related_target()) {
+                (Some(container), Some(related)) => related
+                    .dyn_into::<Node>()
+                    .is_ok_and(|node| container.contains(Some(&node))),
+                _ => false
+            };
+            if !stays_inside {
+                open.set(false);
+            }
+        })
+    };
+
+    {
+        let menu_ref = menu_ref.clone();
+        use_effect_with(*open, move |is_open| {
+            if *is_open && let Some(first) = menu_items(&menu_ref).first() {
+                let _ = first.focus();
+            }
+            || ()
+        });
+    }
+
     let menu_class = if *open {
         "nav-dropdown-menu open"
     } else {
@@ -138,8 +257,15 @@ pub fn NavDropdown(props: &NavDropdownProps) -> Html {
     };
 
     html! {
-        <li class={classes} role="presentation">
+        <li
+            ref={container_ref}
+            class={classes}
+            role="presentation"
+            onkeydown={on_keydown}
+            onfocusout={on_focusout}
+        >
             <button
+                ref={toggle_ref}
                 type="button"
                 class="nav-dropdown-toggle"
                 aria-expanded={if *open { "true" } else { "false" }}
@@ -149,7 +275,7 @@ pub fn NavDropdown(props: &NavDropdownProps) -> Html {
                 { props.toggle_text }
                 <span class="nav-dropdown-caret">{" ▼"}</span>
             </button>
-            <ul class={menu_class} role="menu">
+            <ul ref={menu_ref} class={menu_class} role="menu">
                 { for props.children.iter() }
             </ul>
         </li>

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -25,3 +25,6 @@ mod components;
 
 #[path = "wasm/navigation.rs"]
 mod navigation;
+
+#[path = "wasm/dropdown.rs"]
+mod dropdown;

--- a/tests/wasm/common.rs
+++ b/tests/wasm/common.rs
@@ -29,9 +29,22 @@ pub fn body() -> HtmlElement {
     document().body().unwrap()
 }
 
-/// Allocates a fresh `<div>` under `<body>` for the next render.
+/// Allocates a fresh `<div>` under `<body>` for the next render. Any root left
+/// by a previous test is removed first (matched by the `__test_root` marker
+/// class, so the test-runner's own DOM is untouched) to keep global
+/// `query_selector` calls isolated between tests.
 pub fn fresh_root() -> Element {
-    let root = document().create_element("div").unwrap();
+    let document = document();
+    let stale = document.query_selector_all(".__test_root").unwrap();
+    for index in 0..stale.length() {
+        if let Some(node) = stale.item(index)
+            && let Some(parent) = node.parent_node()
+        {
+            let _ = parent.remove_child(&node);
+        }
+    }
+    let root = document.create_element("div").unwrap();
+    root.set_class_name("__test_root");
     body().append_child(&root).unwrap();
     root
 }

--- a/tests/wasm/dropdown.rs
+++ b/tests/wasm/dropdown.rs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Browser tests for `NavDropdown` keyboard interaction (#217): opening
+//! focuses the first item, arrow keys move a roving focus, and Escape closes
+//! the menu and returns focus to the toggle.
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use web_sys::{HtmlElement, KeyboardEvent, KeyboardEventInit};
+use yew::prelude::*;
+use yew_nav_link::{
+    NavLink, NavList,
+    components::{NavDropdown, NavDropdownItem}
+};
+use yew_router::prelude::*;
+
+use super::common::{TestRoute, document, fresh_root, wait_for_render};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[function_component]
+fn DropdownApp() -> Html {
+    html! {
+        <BrowserRouter>
+            <NavList>
+                <NavDropdown toggle_text="Menu">
+                    <NavDropdownItem>
+                        <NavLink<TestRoute> to={TestRoute::Home}>{ "Home" }</NavLink<TestRoute>>
+                    </NavDropdownItem>
+                    <NavDropdownItem>
+                        <NavLink<TestRoute> to={TestRoute::About}>{ "About" }</NavLink<TestRoute>>
+                    </NavDropdownItem>
+                </NavDropdown>
+            </NavList>
+        </BrowserRouter>
+    }
+}
+
+fn active_element() -> Option<HtmlElement> {
+    document()
+        .active_element()
+        .and_then(|el| el.dyn_into::<HtmlElement>().ok())
+}
+
+fn press(target: &HtmlElement, key: &str) {
+    let init = KeyboardEventInit::new();
+    init.set_key(key);
+    init.set_bubbles(true);
+    let event = KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+    target.dispatch_event(&event).unwrap();
+}
+
+#[wasm_bindgen_test]
+async fn keyboard_opens_moves_focus_and_escapes() {
+    let root = fresh_root();
+    yew::Renderer::<DropdownApp>::with_root(root).render();
+    wait_for_render().await;
+
+    let toggle = document()
+        .query_selector(".nav-dropdown-toggle")
+        .unwrap()
+        .expect("toggle should render")
+        .dyn_into::<HtmlElement>()
+        .unwrap();
+
+    assert_eq!(
+        toggle.get_attribute("aria-expanded").as_deref(),
+        Some("false")
+    );
+
+    toggle.click();
+    wait_for_render().await;
+    assert_eq!(
+        toggle.get_attribute("aria-expanded").as_deref(),
+        Some("true")
+    );
+
+    let links = document()
+        .query_selector_all(".nav-dropdown-menu a[href]")
+        .unwrap();
+    let first = links.item(0).unwrap().dyn_into::<HtmlElement>().unwrap();
+    let second = links.item(1).unwrap().dyn_into::<HtmlElement>().unwrap();
+
+    assert!(
+        active_element().is_some_and(|el| el.is_same_node(Some(first.as_ref()))),
+        "opening the menu should focus the first item"
+    );
+
+    press(&first, "ArrowDown");
+    wait_for_render().await;
+    assert!(
+        active_element().is_some_and(|el| el.is_same_node(Some(second.as_ref()))),
+        "ArrowDown should move focus to the second item"
+    );
+
+    press(&second, "Escape");
+    wait_for_render().await;
+    assert_eq!(
+        toggle.get_attribute("aria-expanded").as_deref(),
+        Some("false")
+    );
+    assert!(
+        active_element().is_some_and(|el| el.is_same_node(Some(toggle.as_ref()))),
+        "Escape should close the menu and return focus to the toggle"
+    );
+}


### PR DESCRIPTION
## Problem

`NavDropdown` set `aria-expanded`/`aria-haspopup` but shipped no keyboard interaction: no Escape-to-close, no arrow-key focus movement, no dismissal on focus leaving the menu. The crate exposed `handle_arrow_key`/`handle_home_end` but the dropdown never wired them, so a keyboard/AT user could open the menu but not operate it.

## Change

`NavDropdown` now:
- moves focus to the first item when the menu opens;
- `ArrowDown`/`ArrowUp` (wrapping) and `Home`/`End` move a roving focus over the menu links, via the existing `utils::keyboard` helpers;
- `Escape` closes the menu and returns focus to the toggle;
- `onfocusout` dismisses the menu when focus leaves the dropdown (tabbing away or clicking outside).

Uses `use_node_ref` for the container/toggle/menu and web-sys focus APIs. `web-sys`/`wasm-bindgen` move from dev- to regular dependencies (both were already in the tree via yew). No public API change — `NavDropdown`'s props and render structure are unchanged.

## Verification

- `cargo nextest`: 460 passed. `clippy` (incl. pedantic+nursery via the pre-commit hook), `+nightly fmt --check`, `cargo-machete`: clean. MSRV 1.96 builds.
- New wasm browser test (`tests/wasm/dropdown.rs`): open→first-item focus, ArrowDown→next, Escape→close+toggle refocus; passes headless. Fixed a latent test-isolation gap in `tests/wasm/common.rs` (global `query_selector` now scoped by clearing prior test roots).
- New Playwright specs for Escape and outside-click dismissal; chromium: 4 passed.
- Browser-only focus code is excluded from native `llvm-cov` (covered by the wasm suite), matching the existing pattern.

Closes #217