### PR TITLE
#231 ci: self-sync sub-crate lockfiles in release PRs and add yank workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -96,3 +96,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+      # release-plz bumps the root crate but not the separate example/ and
+      # fuzz/ workspaces, so their lockfile pins lag the new version and the
+      # release PR would fail `sync-versions.sh --check`. Reconcile them (and
+      # any doc-snippet minor bump) on the release branch automatically.
+      - name: Sync sub-crate lockfiles into the release PR
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+        run: |
+          branch="$(gh pr list --state open --json headRefName,title \
+            --jq 'map(select(.title | startswith("chore: release"))) | .[0].headRefName // ""')"
+          if [ -z "$branch" ]; then
+            echo "No open release PR; nothing to sync."
+            exit 0
+          fi
+          git fetch origin "$branch"
+          git checkout "$branch"
+          ./scripts/sync-versions.sh
+          if git diff --quiet; then
+            echo "Sub-crate lockfiles already in sync."
+            exit 0
+          fi
+          git config user.name "release-plz[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: sync sub-crate lockfiles to release version"
+          git push origin "HEAD:$branch"

--- a/.github/workflows/yank.yml
+++ b/.github/workflows/yank.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Manually yank (or un-yank) a published crates.io version. Yanking keeps the
+# version downloadable for existing lockfiles but stops new dependencies from
+# selecting it — use it for a release published with incomplete or broken
+# contents. Runs on demand with the same CRATES_IO_TOKEN the release pipeline
+# uses, so no local credentials are needed.
+
+name: Yank
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to (un)yank, e.g. 0.11.0"
+        required: true
+        type: string
+      undo:
+        description: "Un-yank instead of yank"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  yank:
+    name: Yank
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'RAprogramm' }}
+    steps:
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
+        with:
+          toolchain: stable
+
+      - name: Yank or un-yank
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          UNDO: ${{ inputs.undo }}
+        run: |
+          if [ "$UNDO" = "true" ]; then
+            echo "Un-yanking yew-nav-link@$VERSION"
+            cargo yank --undo --version "$VERSION" yew-nav-link
+          else
+            echo "Yanking yew-nav-link@$VERSION"
+            cargo yank --version "$VERSION" yew-nav-link
+          fi


### PR DESCRIPTION
## Problem

release-plz bumps the root crate but not the separate `example/` and `fuzz/` workspaces, so their lockfile pins lag and every release PR fails `sync-versions.sh --check` (the `Documentation` job) — it needed a manual lockfile bump for both v0.11.0 and v0.11.1.

## Fix

1. **Self-syncing release PRs** (`.github/workflows/release-plz.yml`): after `release-pr`, run `./scripts/sync-versions.sh` on the release branch and push, so sub-crate lockfiles (and any doc-snippet minor bump) reconcile automatically. Idempotent.
2. **Yank workflow** (`.github/workflows/yank.yml`): `workflow_dispatch` running `cargo yank`/`--undo` with the existing `CRATES_IO_TOKEN`, so a broken published version can be yanked without local credentials.

## Verification

- `actionlint`: clean on both workflows. Pre-commit gates green.
- The yank workflow will be used to yank the incomplete v0.11.0 after merge.

Closes #231