### PR TITLE
#241 ci: publish releases only from release-PR merges

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -39,6 +39,7 @@ jobs:
     name: cargo-mutants
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,8 +5,20 @@
 #   `release-pr` keeps a single release PR open against `main`, bumping
 #   the version and prepending a CHANGELOG section as conventional
 #   commits land;
-#   `release` runs after the release PR is merged — it tags the commit,
-#   publishes to crates.io, and creates the matching GitHub release.
+#   `release` runs ONLY after the release PR is merged — it tags the
+#   commit, publishes to crates.io, and creates the matching GitHub
+#   release.
+#
+# Publishing is gated by `release_always = false` in release-plz.toml:
+# the `release` command only acts when the pushed commit belongs to a
+# release PR (branch `release-plz-*`). A feature PR that bumps the
+# version manually (breaking changes must, to satisfy
+# cargo-semver-checks) therefore never publishes on merge: the
+# release-pr job picks the unpublished version up and opens the curated
+# release PR instead, so the changelog and release notes always exist
+# before anything reaches crates.io. `workflow_dispatch` is the escape
+# hatch for re-running a failed publish on a release commit; `release`
+# is idempotent.
 #
 # Authentication is via a dedicated GitHub App (see
 # `docs/RELEASE_PLZ_APP_SETUP.md`). The App identity is required, not
@@ -25,6 +37,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,8 +11,17 @@ that bumps `Cargo.toml` and prepends a section to `CHANGELOG.md`, and
 when that PR is squash-merged it tags the commit, publishes to
 crates.io, and creates the GitHub release.
 
-There is no manual version-bump path. The maintainer's only release
-action is to review and merge the release PR.
+Publishing has exactly one path: merging the release PR.
+`release_always = false` in `release-plz.toml` makes the `release`
+command act only on commits that belong to a `release-plz-*` branch, so
+nothing reaches crates.io without a reviewed changelog.
+
+One kind of PR bumps the version outside a release PR: a **breaking
+change** must raise `Cargo.toml` to the next minor so the
+`cargo semver-checks` gate can classify the API diff. Merging such a PR
+does **not** publish — the bumped, unpublished version simply flows
+into the next release PR, which carries the curated `CHANGELOG.md`
+section and publishes on merge.
 
 [rplz]: https://release-plz.dev
 
@@ -32,7 +41,9 @@ After 1.0 the standard major/minor/patch rules apply.
 `Semver Checks` (`cargo semver-checks`) runs on every PR and blocks a
 release whose API change exceeds the version bump. release-plz reads
 the same conventional commits to decide the bump, so by the time a
-release PR exists the version and the diff already agree.
+release PR exists the version and the diff already agree. If a publish
+fails on a release commit, re-run it via the workflow's
+`workflow_dispatch` — `release-plz release` is idempotent.
 
 ## How a release happens
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,6 +19,15 @@ git_tag_enable = true
 publish = true
 publish_allow_dirty = false
 release = true
+# Publish only when the merged commit belongs to a release PR (a branch
+# named `release-plz-*`). Without this, `release-plz release` publishes on
+# ANY push where Cargo.toml is ahead of crates.io — a feature PR that bumps
+# the version manually (breaking changes must, to satisfy
+# cargo-semver-checks) would ship straight to crates.io with no curated
+# CHANGELOG section and wrong release notes (this is how 0.11.0 and 0.12.0
+# escaped). With `release_always = false` such a merge instead flows into
+# the next release PR, and publishing happens only when that PR merges.
+release_always = false
 
 [[package]]
 name = "yew-nav-link"


### PR DESCRIPTION
Closes #241.

The release job ran on every push to main and published whenever Cargo.toml was ahead of crates.io, so PRs that bump the version manually (breaking changes must, to satisfy cargo-semver-checks) shipped straight to crates.io — v0.11.0 and v0.12.0 escaped with no curated CHANGELOG section, wrong release notes, and a stale release PR left open (#236).

- `release_always = false` in release-plz.toml: the `release` command now acts only on commits belonging to a `release-plz-*` branch — release-plz's native gate for exactly this flow (verified against the config docs; `release-plz update` parses the config and computes 0.12.1 as next).
- `workflow_dispatch` on the Release-plz workflow as the escape hatch for re-running a failed publish on a release commit (`release` is idempotent).
- Workflow header and RELEASE.md now document the invariant: publishing has exactly one path — merging the release PR; a manual bump in a breaking PR flows into the next release PR instead of publishing.

Verified locally: actionlint and zizmor clean on the workflow; release-plz CLI parses the new config.