### PR TITLE
#246 ci: normalize concurrency settings

### DIFF
--- a/.github/workflows/changelog-refresh.yml
+++ b/.github/workflows/changelog-refresh.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: changelog-refresh
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyse

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,8 +16,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: fuzz-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -29,7 +29,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -28,8 +28,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: mutants-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/release-attestations.yml
+++ b/.github/workflows/release-attestations.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-attestations-${{ github.event.release.tag_name || inputs.tag }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-attestations.yml
+++ b/.github/workflows/release-attestations.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -43,7 +43,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-plz-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analysis:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/yank.yml
+++ b/.github/workflows/yank.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   yank:
     name: Yank

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: zizmor-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

<!-- What does this PR do, and why? Write for the reader of the commit
history on `main`, not just the reviewer. -->

## Changes

- Now all CI workflows follow the same naming patterns
- Some now cancel previous jobs

## Author checklist

- [ ] `cargo +nightly fmt --all`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] `cargo nextest run --all-features` (plus `cargo test --doc` if docs changed)
- [ ] Behaviour / API changes propagated to `README.md`, `docs/` and `docs/REQUIREMENTS.md`
- [ ] Public-API changes reflected in `docs/public-api.txt` (`cargo public-api -sss`) and covered by tests
- [x] Commits follow `#<issue> <type> <description>` (see [`docs/BRANCHING.md`](../docs/BRANCHING.md))

## Reviewer checklist

<!-- Confirmed by the CODEOWNERS reviewer before approving. -->

- [ ] Change is scoped to the linked issue — no unrelated edits
- [ ] Any public-API change is intentional and semver-appropriate
- [ ] Tests exercise the new behaviour, not merely compile it
- [ ] Docs / ADRs reflect any design decision introduced here
- [ ] `CI Success` is green and the branch is up to date with `main`

The full merge policy lives in [`docs/BRANCHING.md`](../docs/BRANCHING.md).

---

Closes #246