### PR TITLE
#248 docs: add KaiCode 2026 winner badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 <a id="top"></a>
 
-# yew-nav-link
+<div align="center">
+
+<a href="https://www.kaicode.org/2026.html"><img src="https://www.kaicode.org/images/2026/yew-nav-link.svg" alt="Winner of the KaiCode 2026 Open Source Festival — first place, Perfect tier" width="170"></a>
+
+<h1>yew-nav-link</h1>
+
+</div>
 
 Enterprise-grade navigation library for [Yew](https://yew.rs) — automatic active state detection and a complete component system.
 


### PR DESCRIPTION
Closes #248

yew-nav-link took first place (Perfect tier) at the KaiCode 2026 Open Source Festival.

## Changes

- Add the official winner laurel to the top of the README, centered, linking to the festival results page.
- The badge is hot-linked from the festival site (project-specific laurel with "Perfect 2026" inscribed), so no image is vendored into the repository.
- Center the project title below the badge; the rest of the header is unchanged.

## Verification

- Both new URLs return HTTP 200.
- `cargo +nightly fmt --check`, `cargo check --all-targets`, `cargo test` (README doctests included) are green locally.