### PR TITLE
#266 ci: drop invalid top-level keys from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -123,14 +123,3 @@ updates:
   # Auto-close PRs when dependencies are updated manually
   # Dependabot will automatically close PRs when it detects
   # that the dependency has been updated manually
-
-# =====================================================
-# SECURITY SETTINGS
-# =====================================================
-
-# Dependabot security updates
-security_updates_enabled: true
-
-# Alert on vulnerable dependencies
-vulnerability-alerts:
-  enabled: true


### PR DESCRIPTION
Closes #266

Dependabot's config validation check fails on every PR touching `.github/dependabot.yml`:

```
The property '#/' contains additional properties ["security_updates_enabled", "vulnerability-alerts"] outside of the schema when none are allowed
```

Neither key is part of the Dependabot configuration schema; security updates and vulnerability alerts are repository settings and are already enabled. Removing the two blocks makes the file schema-valid and unblocks auto-merge on #260.

Verified locally: YAML parses with only `version` and `updates` at the top level, zizmor reports no new findings, actionlint passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated dependency security update and vulnerability alert configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->