### PR TITLE
#268 ci: use a valid pull-request-branch-name separator in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
       - rust
     open-pull-requests-limit: 10
     pull-request-branch-name:
-      separator: /-
+      separator: /
     rebase-strategy: auto
     
     # Version update groups
@@ -94,7 +94,7 @@ updates:
       - github-actions
     open-pull-requests-limit: 5
     pull-request-branch-name:
-      separator: /-
+      separator: /
     rebase-strategy: auto
     
     groups:


### PR DESCRIPTION
Closes #268

The Dependabot config check still failed after #267:

```
The property '#/updates/0/pull-request-branch-name/separator' value "/-" did not match one of the following values: -, /, _
```

`"/-"` was never a valid separator; Dependabot fell back to the default `/`, which is what existing branches already use. Setting `/` explicitly keeps branch naming unchanged and makes the file schema-valid.

Verified locally: the whole file validates against the official Dependabot 2.0 JSON schema with zero errors; zizmor and actionlint unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update branch naming for Cargo and GitHub Actions changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->