### PR TITLE
#271 ci: use bare types as dependabot commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       time: "09:00"
       timezone: Europe/Moscow
     commit-message:
-      prefix: "deps(cargo)"
+      prefix: "chore"
       include: "scope"
     labels:
       - dependencies
@@ -86,7 +86,7 @@ updates:
       time: "09:00"
       timezone: Europe/Moscow
     commit-message:
-      prefix: "ci(deps)"
+      prefix: "ci"
       include: "scope"
     labels:
       - dependencies


### PR DESCRIPTION
Closes #271

With a schema-valid config (#266, #268) Dependabot now honours `commit-message`, and the old settings doubled the scope: `ci(deps)(deps): …` (#270) and `deps(cargo)(deps): …` — the latter using a type the PR title check does not accept.

Prefixes are now bare types (`ci` for github-actions, `chore` for cargo) with `include: scope` supplying `(deps)` / `(deps-dev)`, giving `ci(deps): …` and `chore(deps): …`. The changelog already groups Dependabot commits by author and matches `chore(deps)`.

Verified locally: the file validates against the official Dependabot 2.0 JSON schema with zero errors; actionlint passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update commit messages to use clearer prefixes for Cargo and GitHub Actions changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->